### PR TITLE
Add automated documentation rendering of the wxflow API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,9 +128,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Sphinx documentation
-docs/_build/
-
 # Editor backup files (Emacs, vim)
 *~
 *.sw[a-p]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,32 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+    # You can also specify other tool versions:
+    # nodejs: "19"
+    # rust: "1.64"
+    # golang: "1.19"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+ python:
+    install:
+    - requirements: docs/docs_requirements.txt

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Common set of tools used in weather workflows
 
-## Installation
+### Installation
 ```sh
 $> pip install wxflow
 ```
@@ -27,6 +27,8 @@ $> source venv/bin/activate
 # Run pytests
 (venv) $> pytest -v
 ```
+### Documentation
+Documentation is automatically generated and is available [here](https://wxflow.readthedocs.io/en/latest/).
 
 # Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+![PyPI](https://img.shields.io/pypi/v/:wxflow)
 [![pynorms](https://github.com/NOAA-EMC/wxflow/actions/workflows/pynorms.yaml/badge.svg)](https://github.com/NOAA-EMC/wxflow/actions/workflows/pynorms.yaml)
 [![pytests](https://github.com/NOAA-EMC/wxflow/actions/workflows/pytests.yaml/badge.svg)](https://github.com/NOAA-EMC/wxflow/actions/workflows/pytests.yaml)
-![PyPI](https://img.shields.io/pypi/v/:wxflow)
+[![Documentation Status](https://readthedocs.org/projects/wxflow/badge/?version=latest)](https://wxflow.readthedocs.io/en/latest/?badge=latest)
 
 # Tools for Weather Workflows
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,12 @@
+API
+===
+
+.. toctree::
+  :maxdepth: 2
+
+  yaml_file
+  timetools
+  jinja
+  logger
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,8 +26,6 @@ extensions = [
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-
-
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
@@ -35,4 +33,5 @@ html_theme = 'sphinx_rtd_theme'
 html_theme_path = ["_themes", ]
 html_static_path = ['_static']
 
+# Show documentation from class as well as __init__ docstring
 autoclass_content = 'both'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,34 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
+project = 'wxflow'
+copyright = '2023, NOAA/NWS/NCEP/EMC'
+author = 'NOAA/NWS/NCEP/EMC'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = ["_themes", ]
+html_static_path = ['_static']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,9 @@ author = 'NOAA/NWS/NCEP/EMC'
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
+    "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode"
 ]
 
 templates_path = ['_templates']
@@ -32,3 +34,5 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 html_theme = 'sphinx_rtd_theme'
 html_theme_path = ["_themes", ]
 html_static_path = ['_static']
+
+autoclass_content = 'both'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,58 @@
+.. wxflow documentation master file, created by
+   sphinx-quickstart on Thu Jul  6 11:20:05 2023.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+wxflow
+======
+
+.. image:: https://img.shields.io/pypi/wxflow
+   :target: https://pypi.org/project/wxflow/
+   :alt: PyPI
+.. image:: https://github.com/NOAA-EMC/wxflow/workflows/pynorms/badge.svg
+   :target: https://github.com/NOAA-EMC/wxflow/actions/workflows/pynorms.yaml
+   :alt: pynorms
+.. image:: https://github.com/NOAA-EMC/wxflow/workflows/pytests/badge.svg
+   :target: https://github.com/NOAA-EMC/wxflow/actions/workflows/pytests.yaml
+   :alt: pytests
+
+A Python library of common tools used in weather workflows.
+
+Installation
+------------
+
+.. code-block:: bash
+
+    pip install wxflow
+
+Description
+-----------
+
+wxflow is a Python library of common tools used in weather workflows. It is
+designed to be used in NWP applications such as GFS, GEFS, and RRFS workflows.  Some of the tools
+included in wxflow are:
+
+- **logger**: A generic program-wide logging tool.
+- **yamltools**: A YAML parser that allows loading of nested yaml files and resolves environment variables.
+- **timetools**: A collection of datetime tools that allows for easy transformation between the various formats of datetime used in the applications.
+- **executable**: A tool that allows for running command line programs within the python environment.
+  executables.
+- **jinja**: A jinja tool that allows for the use of Jinja2 templates with filters.
+- **task**: A task tool that allows for the use of a YAML file to configure
+  tasks.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   API Reference <api>
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,9 @@ wxflow
 .. image:: https://github.com/NOAA-EMC/wxflow/workflows/pytests/badge.svg
    :target: https://github.com/NOAA-EMC/wxflow/actions/workflows/pytests.yaml
    :alt: pytests
+.. image:: https://readthedocs.org/projects/wxflow/badge/?version=latest
+    :target: https://wxflow.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
 
 A Python library of common tools used in weather workflows.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,4 @@
-.. wxflow documentation master file, created by
-   sphinx-quickstart on Thu Jul  6 11:20:05 2023.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. wxflow documentation master file
 
 wxflow
 ======

--- a/docs/jinja.rst
+++ b/docs/jinja.rst
@@ -1,0 +1,6 @@
+.. currentmodule:: wxflow
+
+.. autoclass:: Jinja
+    :members:
+    :show-inheritance:
+    :inherited-members:

--- a/docs/logger.rst
+++ b/docs/logger.rst
@@ -1,0 +1,11 @@
+.. currentmodule:: wxflow
+
+.. autoclass:: Logger
+    :members:
+    :show-inheritance:
+    :inherited-members:
+.. autoclass:: ColoredFormatter
+    :members:
+    :show-inheritance:
+    :inherited-members:
+.. autofunction:: logit

--- a/docs/logger.rst
+++ b/docs/logger.rst
@@ -4,8 +4,4 @@
     :members:
     :show-inheritance:
     :inherited-members:
-.. autoclass:: ColoredFormatter
-    :members:
-    :show-inheritance:
-    :inherited-members:
 .. autofunction:: logit

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx-autobuild

--- a/docs/requirements_docs.txt
+++ b/docs/requirements_docs.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx-autobuild
+sphinx-rtd-theme

--- a/docs/timetools.rst
+++ b/docs/timetools.rst
@@ -1,0 +1,18 @@
+.. currentmodule:: wxflow
+
+.. autofunction:: to_datetime
+.. autofunction:: to_timedelta
+.. autofunction:: datetime_to_YMDH
+.. autofunction:: datetime_to_YMD
+.. autofunction:: datetime_to_JDAY
+.. autofunction:: timedelta_to_HMS
+.. autofunction:: strftime
+.. autofunction:: strptime
+.. autofunction:: to_YMDH
+.. autofunction:: to_YMD
+.. autofunction:: to_JDAY
+.. autofunction:: to_julian
+.. autofunction:: to_isotime
+.. autofunction:: to_fv3time
+.. autofunction:: add_to_datetime
+.. autofunction:: add_to_timedelta

--- a/docs/yaml_file.rst
+++ b/docs/yaml_file.rst
@@ -1,0 +1,11 @@
+.. currentmodule:: wxflow
+
+.. autoclass:: YAMLFile
+    :members: save, dump, as_dict
+    :show-inheritance:
+.. autofunction:: parse_yaml
+.. autofunction:: parse_yamltmpl
+.. autofunction:: parse_j2yaml
+.. autofunction:: save_as_yaml
+.. autofunction:: dump_as_yaml
+.. autofunction:: vanilla_yaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ where=src
 
 [options.extras_require]
 dev = pytest>=7; pytest-cov>=3
+docs = sphinx>=4 sphinx_rtd_theme>=0.5
 
 [green]
 file-pattern = test_*.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ where=src
 
 [options.extras_require]
 dev = pytest>=7; pytest-cov>=3
-docs = sphinx>=4 sphinx_rtd_theme>=0.5
+docs = sphinx>=4; sphinx-autobuild; sphinx_rtd_theme>=0.5
 
 [green]
 file-pattern = test_*.py


### PR DESCRIPTION
**Description**
This PR:
- auto renders the API documentation with sphinx and should be ready to be hosted to RTD at https://wxflow.readthedocs.io/en/latest/
- does not change any source code.

This PR is an incomplete documentation and does not include all the classes and functions of the module `wxflow`.  More work is required.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
<!--
- [ ] pytests
-->

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
