### PR TITLE
Remove black and flake8 deps.  They are not available on wcoss2. keep…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ Before opening a PR, please note these guidelines:
 
 **Type of change**
 
-Please delete options that are not relevant.
+<!-- Please delete options that are not relevant. -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -31,11 +31,10 @@ Please delete options that are not relevant.
 <!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
 <!-- Provide instructions so we can reproduce. -->
 <!-- Please also list any relevant details for your test configuration -->
+<!-- If adding a new feature, was an accompanying test added? -->
 
-<!-- Use the following as a guide to list your tests and delete options that are not relevant. Expand as necessary. -->
-<!--
+- [ ] pynorms
 - [ ] pytests
--->
 
 **Checklist**
 

--- a/.github/workflows/pynorms.yaml
+++ b/.github/workflows/pynorms.yaml
@@ -1,22 +1,12 @@
 name: pynorms
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   check_norms:
     runs-on: ubuntu-latest
-    name: Check Python coding norms with pycodestyle
+    name: Check Python coding norms
 
     steps:
-
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip
-        pip install pycodestyle
-
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Run pycodestyle
-      run: |
-        cd $GITHUB_WORKSPACE
-        pycodestyle --verbose --config ./.pycodestyle ./
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pynorms.yaml
+++ b/.github/workflows/pynorms.yaml
@@ -7,6 +7,10 @@ jobs:
     name: Check Python coding norms
 
     steps:
-      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+      - name: Install (upgrade) python dependencies (pycodestyle)
+        run: |
+          pip install --upgrade pip
+          pip install pycodestyle
+      - uses: actions/checkout@v3
       - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,12 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        name: isort (python)
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
+        name: isort
+  - repo: local
     hooks:
-      - id: black
-        language_version: python3
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        language_version: python3
+    - id: pycodestyle
+      name: pycodestyle
+      entry: pycodestyle
+      language: system
+      types: [python]
+      args: ['--config=.pycodestyle']

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -11,7 +11,7 @@ To help speed up the review process please ensure the following:
 
 - The PR addresses an open issue.
 - All tests are passing locally with ``pytest``.
-- The project passes linting with ``black`` and ``flake8``.
+- The project passes linting with ``isort`` and ``pycodestyle``.
 - If adding a new feature you also add documentation.
 
 Developing
@@ -25,13 +25,13 @@ and then clone it locally.
    $ git clone https://github.com/yourusername/wxflow
    $ cd wxflow
 
-This project uses ``isort`` to sort Python import definitions alphabetically, ``black`` to format code and ``flake8`` for linting. We also support ``pre-commit`` to ensure
+This project uses ``isort`` to sort Python import definitions alphabetically and ``pycodestyle`` as the Python style checker against conventions in PEP8.  We also support ``pre-commit`` to ensure
 these have been run. To configure your local environment please install these development dependencies and set up
 the commit hooks.
 
 .. code-block:: bash
 
-   $ pip install isort black flake8 pre-commit
+   $ pip install isort pycodestyle pre-commit
    $ pre-commit install
 
 You can check that things are working correctly by calling pre-commit directly.
@@ -40,8 +40,7 @@ You can check that things are working correctly by calling pre-commit directly.
 
    $ pre-commit run --all-files
    isort......................................Passed
-   black......................................Passed
-   flake8.....................................Passed
+   pycodestyle................................Passed
 
 These checks will be run automatically when you make a commit (if ``pre-commit`` has been installed).
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
   PyYAML>=6.0
   Jinja2>=3.1.2
 tests_require =
-  pytest, pytest-cov, isort, black, flake8
+  pytest, pytest-cov, isort, pycodestyle
 
 [options.packages.find]
 where=src
@@ -53,8 +53,8 @@ where=src
 * = *.txt, *.md
 
 [options.extras_require]
-dev = pytest>=7; pytest-cov>=3; isort>=5; black>=21; flake8>=4; pre-commit>=2; tox>=3
-docs = sphinx>=4; sphinx-autobuild; sphinx_rtd_theme>=0.5; furo>=2023.03.23; sphinx-copybutton
+dev = pytest>=7; pytest-cov>=3; isort>=5; pycodestyle>=2; pre-commit>=2; tox>=3
+docs = sphinx>=4; sphinx-autobuild; sphinx_td_theme>=0.5; furo>=2023.03.23; sphinx-copybutton
 
 [green]
 file-pattern = test_*.py
@@ -66,7 +66,6 @@ run-coverage = true
 [tool:pytest]
 addopts = --cov=wxflow --cov-report=term-missing --cov-report=xml --cov-report=html
 
-[tool:flake8]
-exclude = .git,.github,venv,__pycache__,docs/conf.py,old,build,dist
+[tool:pycodestyle]
+exclude = .git,.github,venv,.vscode,docs/conf.py
 max-line-length = 160
-per-file-ignores = __init__.py: F401


### PR DESCRIPTION
**Description**
This PR:
- removes verbage about black and flake8.
- retains isort and pycodestyle
- runs with `pre-commit` action on GH.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update. Update has been made

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- [ ] pytests
- [ ] pynorms

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
