### PR TITLE
Enable searching for included templates when rendering jinja2 templates.

### DIFF
--- a/.github/workflows/pynorms.yaml
+++ b/.github/workflows/pynorms.yaml
@@ -8,6 +8,8 @@ jobs:
 
     steps:
       - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
       - name: Install (upgrade) python dependencies (pycodestyle)
         run: |
           pip install --upgrade pip

--- a/.github/workflows/pynorms.yaml
+++ b/.github/workflows/pynorms.yaml
@@ -7,12 +7,12 @@ jobs:
     name: Check Python coding norms
 
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install (upgrade) python dependencies (pycodestyle)
         run: |
           pip install --upgrade pip
           pip install pycodestyle
-      - uses: actions/checkout@v3
-      - uses: pre-commit/action@v3.0.0
+      - uses: actions/checkout@v4
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -20,7 +20,7 @@ jobs:
           pip install --upgrade pip
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install wxflow
         run: |
@@ -33,4 +33,4 @@ jobs:
           pytest -v
 
       - name: "Upload coverage to Codecov"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4

--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -34,3 +34,5 @@ jobs:
 
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.11"
 
     - name: Install pypa/build
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dmypy.json
 # Editor backup files (Emacs, vim)
 *~
 *.sw[a-p]
+.DS_Store
 
 # Pycharm IDE files
 .idea/

--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -13,7 +13,8 @@ from .logger import Logger, logit
 from .task import Task
 from .template import Template, TemplateConstants
 from .timetools import *
-from .yaml_file import YAMLFile, save_as_yaml, dump_as_yaml, vanilla_yaml, parse_yaml, parse_j2yaml
+from .yaml_file import (YAMLFile, dump_as_yaml, parse_j2yaml, parse_yaml,
+                        save_as_yaml, vanilla_yaml)
 
 __docformat__ = "restructuredtext"
 __version__ = "0.1.0"

--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -13,8 +13,7 @@ from .logger import Logger, logit
 from .task import Task
 from .template import Template, TemplateConstants
 from .timetools import *
-from .yaml_file import (YAMLFile, dump_as_yaml, parse_j2yaml, parse_yaml,
-                        parse_yamltmpl, save_as_yaml, vanilla_yaml)
+from .yaml_file import YAMLFile, save_as_yaml, dump_as_yaml, vanilla_yaml, parse_yaml, parse_j2yaml
 
 __docformat__ = "restructuredtext"
 __version__ = "0.1.0"

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from pathlib import Path
-from typing import Union, Dict, List
+from typing import Dict, List, Union
 
 import jinja2
 from markupsafe import Markup

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -1,8 +1,7 @@
-import io
 import os
 import sys
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 import jinja2
 from markupsafe import Markup
@@ -48,53 +47,45 @@ class Jinja:
     A wrapper around jinja2 to render templates
     """
 
-    def __init__(self, template_path_or_string: str, data: Dict, allow_missing: bool = True):
+    def __init__(self, template_path_or_string: str,
+                 data: Dict,
+                 allow_missing: bool = True,
+                 searchpath: str | List = '/') -> None:
         """
         Description
         -----------
         Given a path to a (jinja2) template and a data object, substitute the
         template file with data.
         Allow for retaining missing or undefined variables.
+        Also provide additional search paths for templates that may be included in the main template
         Parameters
         ----------
         template_path_or_string : str
             Path to the template file or a templated string
         data : dict
             Data to be substituted into the template
+            TODO: make "data" optional so that the user can render the same template with different data
         allow_missing : bool
             If True, allow for missing or undefined variables
+        searchpath: str | list
+            Additional search paths for templates
         """
+
+        self.jinja2_version = jinja2.__version__
 
         self.data = data
         self.undefined = SilentUndefined if allow_missing else jinja2.StrictUndefined
+        self.template_searchpath = searchpath if isinstance(searchpath, list) else [searchpath]
 
         if os.path.isfile(template_path_or_string):
             self.template_type = 'file'
-            self.template_path = Path(template_path_or_string)
+            template_path = Path(template_path_or_string)
+            template_dir = template_path.parent
+            self.template_file = str(template_path.relative_to(template_dir))
+            self.template_searchpath.append(str(template_dir))
         else:
             self.template_type = 'stream'
             self.template_stream = template_path_or_string
-
-    @property
-    def render(self, data: Dict = None) -> str:
-        """
-        Description
-        -----------
-        Render the Jinja2 template with the data
-        Parameters
-        ----------
-        data: dict (optional)
-        Additional data to be used in the template
-        Not implemented yet.  Placed here for future use
-        Returns
-        -------
-        rendered: str
-        Rendered template into text
-        """
-
-        render_map = {'stream': self._render_stream,
-                      'file': self._render_file}
-        return render_map[self.template_type]()
 
     def get_set_env(self, loader: jinja2.BaseLoader, filters: Dict[str, callable] = None) -> jinja2.Environment:
         """
@@ -112,7 +103,7 @@ class Jinja:
         to_YMD: convert a datetime object to a YYYYMMDD string
         to_julian: convert a datetime object to a julian day
         to_f90bool: convert a boolean to a fortran boolean
-        getenv: read variable from enviornment if defined, else UNDEFINED
+        getenv: read variable from environment if defined, else UNDEFINED
 
         Parameters
         ----------
@@ -139,17 +130,16 @@ class Jinja:
         # Add any additional filters
         if filters is not None:
             for filter_name, filter_func in filters.items():
-                env.filters[filter_name] = filter_func
+                env = self.add_filter_to_env(env, filter_name, filter_func)
 
         return env
 
     @staticmethod
-    def add_filter_env(env: jinja2.Environment, filter_name: str, filter_func: callable):
+    def add_filter_to_env(env: jinja2.Environment, filter_name: str, filter_func: callable) -> jinja2.Environment:
         """
         Description
         -----------
         Add a custom filter to the jinja2 environment
-        Not implemented yet.  Placed here for future use
         Parameters
         ----------
         env: jinja2.Environment
@@ -168,22 +158,38 @@ class Jinja:
 
         return env
 
-    def _render_stream(self, filters: Dict[str, callable] = None):
+    @property
+    def render(self) -> str:
+        """
+        Description
+        -----------
+        Render the Jinja2 template with the data
+        Parameters
+        ----------
+        None
+        Returns
+        -------
+        rendered: str
+        Rendered template into text
+        """
+
+        render_map = {'stream': self._render_stream,
+                      'file': self._render_file}
+        return render_map[self.template_type]()
+
+    def _render_stream(self) -> str:
         loader = jinja2.BaseLoader()
-        env = self.get_set_env(loader, filters)
+        env = self.get_set_env(loader)
         template = env.from_string(self.template_stream)
         return self._render_template(template)
 
-    def _render_file(self, data: Dict = None, filters: Dict[str, callable] = None):
-        template_dir = self.template_path.parent
-        template_file = self.template_path.relative_to(template_dir)
-
-        loader = jinja2.FileSystemLoader(template_dir)
-        env = self.get_set_env(loader, filters)
-        template = env.get_template(str(template_file))
+    def _render_file(self) -> str:
+        loader = jinja2.FileSystemLoader(self.template_searchpath)
+        env = self.get_set_env(loader)
+        template = env.get_template(self.template_file)
         return self._render_template(template)
 
-    def _render_template(self, template: jinja2.Template):
+    def _render_template(self, template: jinja2.Template) -> str:
         """
         Description
         -----------
@@ -196,29 +202,6 @@ class Jinja:
         -------
         rendered: str
         """
-        try:
-            rendered = template.render(**self.data)
-        except jinja2.UndefinedError as ee:
-            raise Exception(f"Undefined variable in Jinja2 template\n{ee}")
-
-        return rendered
-
-    def _render(self, template_name: str, loader: jinja2.BaseLoader) -> str:
-        """
-        Description
-        -----------
-        Internal method to render a jinja2 template
-        Parameters
-        ----------
-        template_name: str
-        loader: jinja2.BaseLoader
-        Returns
-        -------
-        rendered: str
-        rendered template
-        """
-        env = jinja2.Environment(loader=loader, undefined=self.undefined)
-        template = env.get_template(template_name)
         try:
             rendered = template.render(**self.data)
         except jinja2.UndefinedError as ee:
@@ -242,6 +225,7 @@ class Jinja:
         with open(output_file, 'wb') as fh:
             fh.write(self.render.encode("utf-8"))
 
+    @property
     def dump(self) -> None:
         """
         Description
@@ -251,5 +235,4 @@ class Jinja:
         -------
         None
         """
-        io.TextIOWrapper(sys.stdout.buffer,
-                         encoding="utf-8").write(self.render)
+        sys.stdout.write(self.render)

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from pathlib import Path
-from typing import Dict, List
+from typing import Union, Dict, List
 
 import jinja2
 from markupsafe import Markup
@@ -50,7 +50,7 @@ class Jinja:
     def __init__(self, template_path_or_string: str,
                  data: Dict,
                  allow_missing: bool = True,
-                 searchpath: str | List = '/') -> None:
+                 searchpath: Union[str, List] = '/') -> None:
         """
         Description
         -----------

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -68,7 +68,7 @@ class Jinja:
         allow_missing : bool
             If True, allow for missing or undefined variables
         searchpath: str | list
-            Additional search paths for templates
+            Additional search paths for templates (default '/')
         """
 
         self.jinja2_version = jinja2.__version__
@@ -76,6 +76,9 @@ class Jinja:
         self.data = data
         self.undefined = SilentUndefined if allow_missing else jinja2.StrictUndefined
         self.template_searchpath = searchpath if isinstance(searchpath, list) else [searchpath]
+        # Add a default search path if the user has not provided one
+        if '/' not in self.template_searchpath:
+            self.template_searchpath.insert(0, '/')
 
         if os.path.isfile(template_path_or_string):
             self.template_type = 'file'

--- a/src/wxflow/schema.py
+++ b/src/wxflow/schema.py
@@ -606,7 +606,7 @@ class Schema(object):
                         return_schema["allOf"] = all_of_values
                 elif flavor == COMPARABLE:
                     return_schema["const"] = _to_json_type(s)
-                elif flavor == VALIDATOR and type(s) == Regex:
+                elif flavor == VALIDATOR and type(s) is Regex:
                     return_schema["type"] = "string"
                     return_schema["pattern"] = s.pattern_str
                 else:

--- a/src/wxflow/yaml_file.py
+++ b/src/wxflow/yaml_file.py
@@ -1,8 +1,8 @@
 import datetime
 import json
 import os
-import sys
 import re
+import sys
 from typing import Any, Dict, List
 
 import yaml

--- a/src/wxflow/yaml_file.py
+++ b/src/wxflow/yaml_file.py
@@ -3,7 +3,7 @@ import json
 import os
 import re
 import sys
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 import yaml
 
@@ -156,7 +156,7 @@ def vanilla_yaml(ctx):
         return ctx
 
 
-def parse_j2yaml(path: str, data: Dict, searchpath: str | List = '/') -> Dict[str, Any]:
+def parse_j2yaml(path: str, data: Dict, searchpath: Union[str, List] = '/') -> Dict[str, Any]:
     """
     Description
     -----------

--- a/src/wxflow/yaml_file.py
+++ b/src/wxflow/yaml_file.py
@@ -1,16 +1,16 @@
 import datetime
 import json
 import os
+import sys
 import re
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import yaml
 
 from .attrdict import AttrDict
 from .jinja import Jinja
-from .template import Template, TemplateConstants
 
-__all__ = ['YAMLFile', 'parse_yaml', 'parse_yamltmpl', 'parse_j2yaml',
+__all__ = ['YAMLFile', 'parse_yaml', 'parse_j2yaml',
            'save_as_yaml', 'dump_as_yaml', 'vanilla_yaml']
 
 
@@ -39,9 +39,11 @@ class YAMLFile(AttrDict):
     def save(self, target):
         save_as_yaml(self, target)
 
+    @property
     def dump(self):
         return dump_as_yaml(self)
 
+    @property
     def as_dict(self):
         return vanilla_yaml(self)
 
@@ -54,7 +56,7 @@ def save_as_yaml(data, target):
 
 
 def dump_as_yaml(data):
-    return yaml.dump(vanilla_yaml(data),
+    return yaml.dump(vanilla_yaml(data), sys.stdout, encoding='utf-8',
                      width=100000, sort_keys=False)
 
 
@@ -154,57 +156,25 @@ def vanilla_yaml(ctx):
         return ctx
 
 
-def parse_j2yaml(path: str, data: Dict) -> Dict[str, Any]:
+def parse_j2yaml(path: str, data: Dict, searchpath: str | List = '/') -> Dict[str, Any]:
     """
     Description
     -----------
     Load a compound jinja2-templated yaml file and resolve any templated variables.
     The jinja2 templates are first resolved and then the rendered template is parsed as a yaml.
-    Finally, any remaining $( ... ) templates are resolved
 
     Parameters
     ----------
     path : str
-        the path to the yaml file
+        the path to the jinja2 templated yaml file
     data : Dict[str, Any], optional
         the context for jinja2 templating
+    searchpath: str | List
+        additional search paths for included jinja2 templates
     Returns
     -------
     Dict[str, Any]
         the dict configuration
     """
-    jenv = Jinja(path, data)
-    yaml_file = jenv.render
-    yaml_dict = YAMLFile(data=yaml_file)
-    yaml_dict = Template.substitute_structure(
-        yaml_dict, TemplateConstants.DOLLAR_PARENTHESES, data.get)
 
-    # If the input yaml file included other yamls with jinja2 templates, then we need to re-parse the jinja2 templates in them
-    jenv2 = Jinja(json.dumps(yaml_dict, indent=4), data)
-    yaml_file2 = jenv2.render
-    yaml_dict = YAMLFile(data=yaml_file2)
-
-    return yaml_dict
-
-
-def parse_yamltmpl(path: str, data: Dict = None) -> Dict[str, Any]:
-    """
-    Description
-    -----------
-    Load a simple templated yaml file and then resolve any templated variables defined as $( ... )
-    Parameters
-    ----------
-    path : str
-        the path to the yaml file
-    data : Dict[str, Any], optional
-        the context for wxflow.Template templating
-    Returns
-    -------
-    Dict[str, Any]
-        the dict configuration
-    """
-    yaml_dict = YAMLFile(path=path)
-    if data is not None:
-        yaml_dict = Template.substitute_structure(yaml_dict, TemplateConstants.DOLLAR_PARENTHESES, data.get)
-
-    return yaml_dict
+    return YAMLFile(data=Jinja(path, data, searchpath=searchpath).render)

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -6,6 +6,7 @@ from wxflow import Jinja, to_isotime
 
 current_date = datetime.now()
 j2tmpl = """Hello {{ name }}! {{ greeting }} It is: {{ current_date | to_isotime }}"""
+j2includetmpl = """I am {{ my_name }}. {% include 'template.j2' %}"""
 
 
 @pytest.fixture
@@ -13,6 +14,10 @@ def create_template(tmp_path):
     file_path = tmp_path / 'template.j2'
     with open(file_path, 'w') as fh:
         fh.write(j2tmpl)
+
+    file_path = tmp_path / 'include_template.j2'
+    with open(file_path, 'w') as fh:
+        fh.write(j2includetmpl)
 
 
 def test_render_stream():
@@ -35,3 +40,12 @@ def test_render_file(tmp_path, create_template):
     data = {"name": "Jane", "greeting": "How are you?", "current_date": current_date}
     j = Jinja(str(file_path), data, allow_missing=False)
     assert j.render == f"Hello Jane! How are you? It is: {to_isotime(current_date)}"
+
+
+def test_include(tmp_path, create_template):
+
+    file_path = tmp_path / 'include_template.j2'
+
+    data = {"my_name": "Jill", "name": "Joe", "greeting": "How are you?", "current_date": current_date}
+    j = Jinja(str(file_path), data, allow_missing=False)
+    assert j.render == f"I am Jill. Hello Joe! How are you? It is: {to_isotime(current_date)}"

--- a/tests/test_yaml_file.py
+++ b/tests/test_yaml_file.py
@@ -3,8 +3,7 @@ from datetime import datetime
 
 import pytest
 
-from wxflow import (YAMLFile, dump_as_yaml, parse_j2yaml, parse_yamltmpl,
-                    save_as_yaml)
+from wxflow import (YAMLFile, parse_j2yaml, save_as_yaml)
 
 host_yaml = """
 host:
@@ -19,25 +18,14 @@ config:
     host_file: !INC ${TMP_PATH}/host.yaml
 """
 
-tmpl_yaml = """
-config:
-    config_file: !ENV ${TMP_PATH}/config.yaml
-    user: !ENV ${USER}
-    host_file: !INC ${TMP_PATH}/host.yaml
-tmpl:
-    cdate: '{{PDY}}{{cyc}}'
-    homedir: /home/$(user)
-"""
-# Note the quotes ' ' around {{ }}.  These quotes are necessary for yaml otherwise yaml will fail parsing
-
 j2tmpl_yaml = """
 config:
     config_file: !ENV ${TMP_PATH}/config.yaml
     user: !ENV ${USER}
     host_file: !INC ${TMP_PATH}/host.yaml
 tmpl:
-    cdate: '{{ current_cycle | to_YMD }}{{ current_cycle | strftime('%H') }}'
-    homedir: /home/$(user)
+    cdate: {{ current_cycle | to_YMD }}{{ current_cycle | strftime('%H') }}
+    homedir: /home/{{ user }}
 """
 
 
@@ -46,7 +34,6 @@ def create_template(tmpdir):
     """Create temporary templates for testing"""
     tmpdir.join('host.yaml').write(host_yaml)
     tmpdir.join('config.yaml').write(conf_yaml)
-    tmpdir.join('tmpl.yaml').write(tmpl_yaml)
     tmpdir.join('j2tmpl.yaml').write(j2tmpl_yaml)
 
 
@@ -62,23 +49,6 @@ def test_yaml_file(tmp_path, create_template):
 
     # Read in the yaml file and compare w/ conf
     yaml_in = YAMLFile(path=str(yaml_out))
-
-    assert yaml_in == conf
-
-
-def test_yaml_file_with_templates(tmp_path, create_template):
-
-    # Set env. variable
-    os.environ['TMP_PATH'] = str(tmp_path)
-    data = {'user': os.environ['USER']}
-    conf = parse_yamltmpl(path=str(tmp_path / 'tmpl.yaml'), data=data)
-
-    # Write out yaml file
-    yaml_out = tmp_path / 'tmpl_output.yaml'
-    save_as_yaml(conf, yaml_out)
-
-    # Read in the yaml file and compare w/ conf
-    yaml_in = YAMLFile(path=yaml_out)
 
     assert yaml_in == conf
 

--- a/tests/test_yaml_file.py
+++ b/tests/test_yaml_file.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import pytest
 
-from wxflow import (YAMLFile, parse_j2yaml, save_as_yaml)
+from wxflow import YAMLFile, parse_j2yaml, save_as_yaml
 
 host_yaml = """
 host:


### PR DESCRIPTION
<!-- PLEASE READ -->
<!--
Before opening a PR, please note these guidelines:

- Each PR should only address ONE topic and have an associated issue
- No hardcoded or paths to personal directories should be present
- No temporary or backup files should be committed
- Any code that was disabled by being commented out should be removed
-->

**Description**
The current implementation of jinja2 rendering was unable to support `include` when the included template was in a location not directly under the current template directory.
This PR:
- allows jinja to search for templates in paths that are provided as `searchpath` as well as from `/`
- removes the parsing of mixed jinja and other template form `$( )` from function `parse_j2yaml`.  This was a stop gap measure to allow prototyping in the DA applications.  Those have now matured that this stop gap needed to be addressed holistically. 
- contains some minor code cleanup where appropriate in `jinja2.py` and `yaml_file.py`.  Test for the `include` is added.
- updates github actions versions for checkout, setup-python.  Also updates the authentication to code-cov v4 that requires use of token stored as a secret.

**Type of change**

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
<!-- If adding a new feature, was an accompanying test added? -->

- [X] pynorms
- [X] pytests
- [X] in a downstream DA application with robust use of `include` including nesting.

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
