### PR TITLE
if a key is missing, report with a KeyError in AttrDict

### DIFF
--- a/src/wxflow/attrdict.py
+++ b/src/wxflow/attrdict.py
@@ -81,7 +81,7 @@ class AttrDict(dict):
     def __missing__(self, name):
         if object.__getattribute__(self, '__frozen'):
             raise KeyError(name)
-        return self.__class__(__parent=self, __key=name)
+        raise KeyError(name)
 
     def __delattr__(self, name):
         del self[name]

--- a/tests/test_attrdict.py
+++ b/tests/test_attrdict.py
@@ -1,0 +1,19 @@
+import pytest
+
+from wxflow import AttrDict
+
+TEST_VAL = [1, 2, 3]
+TEST_DICT = {'a': {'b': {'c': TEST_VAL}}}
+
+
+def test_set_one_level_item():
+    some_dict = {'a': TEST_VAL}
+    prop = AttrDict()
+    prop['a'] = TEST_VAL
+    assert prop == some_dict
+
+
+def test_missing():
+    prop = AttrDict(TEST_DICT)
+    with pytest.raises(KeyError):
+        prop['b']


### PR DESCRIPTION
**Description**

When a key is missing in a `AttrDict`, raise a `KeyError` consistent with `dict`.

Fixes #14 

**Type of change**

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
<!-- If adding a new feature, was an accompanying test added? -->

- [X] pynorms
- [X] pytests

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
