### PR TITLE
expose a couple of specific sqlite3 error codes to Class object

### DIFF
--- a/src/wxflow/sqlitedb.py
+++ b/src/wxflow/sqlitedb.py
@@ -3,6 +3,12 @@ from typing import Any, List, Optional, Tuple
 
 __all__ = ["SQLiteDB"]
 
+class SQLiteDBError(Exception):
+    """
+    Base class for SQLiteDB exceptions.
+    """
+    OperationalError = sqlite3.OperationalError
+    IntegrityError = sqlite3.IntegrityError
 
 class SQLiteDB:
     """
@@ -17,8 +23,7 @@ class SQLiteDB:
 
     """
 
-    OperationalError = sqlite3.OperationalError
-    IntegrityError = sqlite3.IntegrityError
+    Error = SQLiteDBError
 
     def __init__(self, db_name: str) -> None:
         self.db_name = db_name

--- a/src/wxflow/sqlitedb.py
+++ b/src/wxflow/sqlitedb.py
@@ -17,6 +17,9 @@ class SQLiteDB:
 
     """
 
+    OperationalError = sqlite3.OperationalError
+    IntegrityError = sqlite3.IntegrityError
+
     def __init__(self, db_name: str) -> None:
         self.db_name = db_name
         self.connection: Optional[sqlite3.Connection] = None

--- a/src/wxflow/sqlitedb.py
+++ b/src/wxflow/sqlitedb.py
@@ -3,12 +3,14 @@ from typing import Any, List, Optional, Tuple
 
 __all__ = ["SQLiteDB"]
 
+
 class SQLiteDBError(Exception):
     """
     Base class for SQLiteDB exceptions.
     """
     OperationalError = sqlite3.OperationalError
     IntegrityError = sqlite3.IntegrityError
+
 
 class SQLiteDB:
     """


### PR DESCRIPTION
**Description**

We request adding a couple of key sqlite3 error codes to be exposed by the wxflow SQLiteDB Class so the user can specifically query for the error strings with then the are appropriately encountered for a reaction.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

The re-action to using try block when a uniqueness was violated was appropriately observed in the driver code using the class.

- [ ] pynorms
- [ ] pytests

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
