### PR TITLE
Add a test to demonstrate issue 13 is not an issue

### DIFF
--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -4,7 +4,7 @@ from .attrdict import AttrDict
 from .configuration import (Configuration, cast_as_dtype,
                             cast_strdict_as_dtypedict)
 from .exceptions import WorkflowException, msg_except_handle
-from .executable import CommandNotFoundError, Executable, which
+from .executable import CommandNotFoundError, Executable, ProcessError, which
 from .factory import Factory
 from .file_utils import FileHandler
 from .fsutils import chdir, cp, mkdir, mkdir_p, rm_p, rmdir

--- a/src/wxflow/executable.py
+++ b/src/wxflow/executable.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from typing import Any, List, Optional, Union
 
-__all__ = ["Executable", "which", "CommandNotFoundError"]
+__all__ = ["Executable", "which", "CommandNotFoundError", "ProcessError"]
 
 
 class Executable:

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -60,6 +60,7 @@ def test_which(tmpdir):
         assert exe is not None
         assert exe.path == path
 
+
 @pytest.mark.skip(reason="test passes locally, but fails in GH runner")
 def test_stderr(tmp_path):
     """

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from wxflow import CommandNotFoundError, Executable, which
+from wxflow import CommandNotFoundError, Executable, ProcessError, which
 
 script = """#!/bin/bash
 echo ${USER}
@@ -59,3 +59,25 @@ def test_which(tmpdir):
         exe = which("test.x")
         assert exe is not None
         assert exe.path == path
+
+
+def test_stderr(tmp_path):
+    """
+    Tests the `stderr` attribute of the `Executable` class
+    """
+    cmd = which("ls", required=True)
+
+    stdout_file = tmp_path / 'stdout'
+    stderr_file = tmp_path / 'stderr'
+    with pytest.raises(ProcessError):
+        cmd("--help", output=str(stdout_file), error=str(stderr_file))
+
+    # Assert there is no stdout
+    with open(str(stdout_file)) as fh:
+        assert fh.read() == ''
+
+    # Assert stderr is not empty, '--help' is an unrecognized option
+    with open(str(stderr_file)) as fh:
+        stderr = fh.read()
+        assert stderr != ''
+        print(stderr)

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -65,19 +65,21 @@ def test_stderr(tmp_path):
     """
     Tests the `stderr` attribute of the `Executable` class
     """
-    cmd = which("ls", required=True)
+    cmd = which("which", required=True)
 
     stdout_file = tmp_path / 'stdout'
     stderr_file = tmp_path / 'stderr'
     with pytest.raises(ProcessError):
-        cmd("--help", output=str(stdout_file), error=str(stderr_file))
+        cmd("-h", output=str(stdout_file), error=str(stderr_file))
 
     # Assert there is no stdout
     with open(str(stdout_file)) as fh:
         assert fh.read() == ''
 
-    # Assert stderr is not empty, '--help' is an unrecognized option
+    # Assert stderr is not empty, '-h' is a bad option for `which`
     with open(str(stderr_file)) as fh:
         stderr = fh.read()
         assert stderr != ''
-        print(stderr)
+        # Depending on the OS, the error message may vary
+        # This was seen on macOS
+        # assert stderr == "/usr/bin/which: illegal option -- h" + '\n' + "usage: which [-as] program ..." + '\n'

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -66,6 +66,8 @@ def test_stderr(tmp_path):
     Tests the `stderr` attribute of the `Executable` class
     """
 
+    os.environ["PATH"] = "/usr/bin:/bin"
+
     cmd = which("ls", required=True)
 
     stdout_file = tmp_path / 'stdout'

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -61,19 +61,16 @@ def test_which(tmpdir):
         assert exe.path == path
 
 
-@pytest.mark.skip(reason="test passes locally, but fails in GH runner")
 def test_stderr(tmp_path):
     """
     Tests the `stderr` attribute of the `Executable` class
-    TODO: This test fails in the GH runner, but passes locally. Investigate why.
     """
 
     cmd = which("ls", required=True)
 
     stdout_file = tmp_path / 'stdout'
     stderr_file = tmp_path / 'stderr'
-    with pytest.raises(ProcessError):
-        cmd("--help", output=str(stdout_file), error=str(stderr_file))
+    cmd("--myopt", output=str(stdout_file), error=str(stderr_file), fail_on_error=False)
 
     # Assert there is no stdout
     with open(str(stdout_file)) as fh:
@@ -83,7 +80,8 @@ def test_stderr(tmp_path):
     with open(str(stderr_file)) as fh:
         stderr = fh.read()
         assert stderr != ''
+        print(stderr)
         # Depending on the OS, the error message may vary
         # This was seen on macOS
-        # assert stderr == "ls: unrecognized option `--help'" + '\n' + \
+        # assert stderr == "ls: unrecognized option `--myopt'" + '\n' + \
         # "usage: ls [-@ABCFGHILOPRSTUWabcdefghiklmnopqrstuvwxy1%,] [--color=when] [-D format] [file ...]" + '\n'

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -60,14 +60,12 @@ def test_which(tmpdir):
         assert exe is not None
         assert exe.path == path
 
-
+@pytest.mark.skip(reason="test passes locally, but fails in GH runner")
 def test_stderr(tmp_path):
     """
     Tests the `stderr` attribute of the `Executable` class
+    TODO: This test fails in the GH runner, but passes locally. Investigate why.
     """
-
-    # Put "/usr/bin" and "/bin" in the PATH
-    os.environ["PATH"] = "/usr/bin:/bin"
 
     cmd = which("ls", required=True)
 

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -65,21 +65,26 @@ def test_stderr(tmp_path):
     """
     Tests the `stderr` attribute of the `Executable` class
     """
-    cmd = which("which", required=True)
+
+    # Put "/usr/bin" and "/bin" in the PATH
+    os.environ["PATH"] = "/usr/bin:/bin"
+
+    cmd = which("ls", required=True)
 
     stdout_file = tmp_path / 'stdout'
     stderr_file = tmp_path / 'stderr'
     with pytest.raises(ProcessError):
-        cmd("-h", output=str(stdout_file), error=str(stderr_file))
+        cmd("--help", output=str(stdout_file), error=str(stderr_file))
 
     # Assert there is no stdout
     with open(str(stdout_file)) as fh:
         assert fh.read() == ''
 
-    # Assert stderr is not empty, '-h' is a bad option for `which`
+    # Assert stderr is not empty, '--help' is an unrecognized option
     with open(str(stderr_file)) as fh:
         stderr = fh.read()
         assert stderr != ''
         # Depending on the OS, the error message may vary
         # This was seen on macOS
-        # assert stderr == "/usr/bin/which: illegal option -- h" + '\n' + "usage: which [-as] program ..." + '\n'
+        # assert stderr == "ls: unrecognized option `--help'" + '\n' + \
+        # "usage: ls [-@ABCFGHILOPRSTUWabcdefghiklmnopqrstuvwxy1%,] [--color=when] [-D format] [file ...]" + '\n'


### PR DESCRIPTION
**Description**
This PR:
- adds a test to demonstrate the `stderr` file is not binary by reading the contents and printing them

Fixes #13 

**Type of change**

- [X] New feature (non-breaking change which adds functionality) Adds a test.

**How Has This Been Tested?**

- [X] pynorms
- [X] pytests

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
