### PR TITLE
Expand jinja environment

### DIFF
--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Union
 import jinja2
 from markupsafe import Markup
 
+from .template import TemplateConstants
 from .timetools import (add_to_datetime, strftime, to_fv3time, to_isotime,
                         to_julian, to_timedelta, to_YMD, to_YMDH)
 
@@ -134,11 +135,11 @@ class Jinja:
         """
 
         env = jinja2.Environment(loader=loader, undefined=self.undefined)
-        env["DOLLAR_CURLY_BRACE"} = TemplateConstants.DOLLAR_CURLY_BRACE
-        env["DOLLAR_PARENTHESES"} = TemplateConstants.DOLLAR_PARENTHESES
-        env["DOUBLE_CURLY_BRACES"} = TemplateConstants.DOUBLE_CURLY_BRACES
-        env["AT_SQUARE_BRACES"} = TemplateConstants.AT_SQUARE_BRACES
-        env["AT_ANGLE_BRACKETS"} = TemplateConstants.AT_ANGLE_BRACKETS
+        env.extend(DOLLAR_CURLY_BRACE=TemplateConstants.DOLLAR_CURLY_BRACE,
+                   DOLLAR_PARENTHESES=TemplateConstants.DOLLAR_PARENTHESES,
+                   DOUBLE_CURLY_BRACES=TemplateConstants.DOUBLE_CURLY_BRACES,
+                   AT_SQUARE_BRACES=TemplateConstants.AT_SQUARE_BRACES,
+                   AT_ANGLE_BRACKETS=TemplateConstants.AT_ANGLE_BRACKETS)
 
         env.filters["strftime"] = lambda dt, fmt: strftime(dt, fmt)
         env.filters["to_isotime"] = lambda dt: to_isotime(dt) if not isinstance(dt, SilentUndefined) else dt

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -6,8 +6,8 @@ from typing import Dict, List, Union
 import jinja2
 from markupsafe import Markup
 
-from .timetools import (strftime, to_fv3time, to_isotime, to_julian, to_YMD,
-                        to_YMDH)
+from .timetools import (add_to_datetime, strftime, to_fv3time, to_isotime,
+                        to_julian, to_timedelta, to_YMD, to_YMDH)
 
 __all__ = ['Jinja']
 
@@ -108,6 +108,8 @@ class Jinja:
         to_f90bool: convert a boolean to a fortran boolean
         relpath: convert a full path to a relative path based on an input root_path
         getenv: read variable from environment if defined, else UNDEFINED
+        to_timedelta: convert a string to a timedelta object
+        add_to_datetime: add time to a datetime, return new datetime object
 
         Parameters
         ----------
@@ -131,6 +133,8 @@ class Jinja:
         env.filters["to_f90bool"] = lambda bool: ".true." if bool else ".false."
         env.filters['getenv'] = lambda name, default='UNDEFINED': os.environ.get(name, default)
         env.filters["relpath"] = lambda pathname, start=os.curdir: os.path.relpath(pathname, start)
+        env.filters["add_to_datetime"] = lambda dt, delta: add_to_datetime(dt, delta) if not (isinstance(dt, SilentUndefined) or isinstance(delta, SilentUndefined)) else dt
+        env.filters["to_timedelta"] = lambda delta_str: to_timedelta(delta_str) if not isinstance(delta_str, SilentUndefined) else delta_str
 
         # Add any additional filters
         if filters is not None:

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Union
 import jinja2
 from markupsafe import Markup
 
-from .template import TemplateConstants, Template
 from .timetools import (add_to_datetime, strftime, to_fv3time, to_isotime,
                         to_julian, to_timedelta, to_YMD, to_YMDH)
 
@@ -111,21 +110,11 @@ class Jinja:
         getenv: read variable from environment if defined, else UNDEFINED
         to_timedelta: convert a string to a timedelta object
         add_to_datetime: add time to a datetime, return new datetime object
-        template_substitute_structure: traverses a dictionary and substitutes
-            variables in fields, lists, and nested dictionaries
 
         The Expression Statement extension "jinja2.ext.do", which enables
             {% do ... %} statements.  These are useful for appending to lists.
             e.g. {{ bar.append(foo) }} would print "None" to the parsed jinja
             template, but {% do bar.append(foo) %} would not.
-
-        Additionally, the following TemplateConstants are passed into the
-        environment:
-        DOLLAR_CURLY_BRACE
-        DOLLAR_PARENTHESES
-        DOUBLE_CURLY_BRACES
-        AT_SQUARE_BRACES
-        AT_ANGLE_BRACKETS
 
         Parameters
         ----------
@@ -140,12 +129,6 @@ class Jinja:
         """
 
         env = jinja2.Environment(loader=loader, undefined=self.undefined)
-
-        env.globals["DOLLAR_CURLY_BRACE"] = TemplateConstants.DOLLAR_CURLY_BRACE
-        env.globals["DOLLAR_PARENTHESES"] = TemplateConstants.DOLLAR_PARENTHESES
-        env.globals["DOUBLE_CURLY_BRACES"] = TemplateConstants.DOUBLE_CURLY_BRACES
-        env.globals["AT_SQUARE_BRACES"] = TemplateConstants.AT_SQUARE_BRACES
-        env.globals["AT_ANGLE_BRACKETS"] = TemplateConstants.AT_ANGLE_BRACKETS
 
         env.add_extension("jinja2.ext.do")
 
@@ -163,17 +146,6 @@ class Jinja:
                 if not (isinstance(dt, SilentUndefined) or isinstance(delta, SilentUndefined))
                 else dt if isinstance(dt, SilentUndefined) else delta)
         env.filters["to_timedelta"] = lambda delta_str: to_timedelta(delta_str) if not isinstance(delta_str, SilentUndefined) else delta_str
-        env.filters["template_substitute_structure"] = (
-                lambda structure_to_substitute, var_type, get_value:
-                Template.substitute_structure(structure_to_substitute,
-                                              var_type,
-                                              get_value)
-                if not (isinstance(structure_to_substitute, SilentUndefined) or
-                        isinstance(var_type, SilentUndefined) or
-                        isinstance(get_value, SilentUndefined))
-                else structure_to_substitute if isinstance(structure_to_substitute, SilentUndefined)
-                else var_type if isinstance(var_type, SilentUndefined)
-                else get_value)
 
         # Add any additional filters
         if filters is not None:

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -133,7 +133,8 @@ class Jinja:
         env.filters["to_f90bool"] = lambda bool: ".true." if bool else ".false."
         env.filters['getenv'] = lambda name, default='UNDEFINED': os.environ.get(name, default)
         env.filters["relpath"] = lambda pathname, start=os.curdir: os.path.relpath(pathname, start)
-        env.filters["add_to_datetime"] = lambda dt, delta: add_to_datetime(dt, delta) if not (isinstance(dt, SilentUndefined) or isinstance(delta, SilentUndefined)) else dt
+        env.filters["add_to_datetime"] = (lambda dt, delta: add_to_datetime(dt, delta)
+                                          if not (isinstance(dt, SilentUndefined) or isinstance(delta, SilentUndefined)) else dt)
         env.filters["to_timedelta"] = lambda delta_str: to_timedelta(delta_str) if not isinstance(delta_str, SilentUndefined) else delta_str
 
         # Add any additional filters


### PR DESCRIPTION
**Description**
This adds ~three~ new features to the `Jinja` class:
<del>1. `Template.substitute_structure` is now available as a filter.  This is useful for parsing jinja templates that reference multiple similar variables (e.g. ensemble member directories).  A template for the ensemble members can be passed into the jinja context dictionary and used to construct the final variables based on iterators, cycle date/time, etc.
    - For example, if 20 ensemble members each have data in `data/YYYYMMDD/HH/analysis/mem###`, one could define `'ANALYSIS_tmpl' : "data/${YMD}/{HH}/analysis/mem{MEM}", 'current_cycle': datetime.datetime(year=2024, month=5, day=3, hour=6)`
    - Then in the template:</del>

~`{% set cycle_YMD = to_YMD(current_cycle) %}`~
~`{% set cycle_HH = strftime(current_cycle, "%H") %}`~
~`{% for mem in range(1,21) %}`~
~`{% set mem3 = '%03d' % mem %}`~
~`{% set tmpl_dict = {'YMD': cycle_YMD, 'HH': cycle_HH, 'MEM': mem3} %}`~
~`{{ ANALYSIS_tmpl | template_substitute_structure(DOLLAR_CURLY_BRACE, tmpl_dict.get) }}`~
~`{% endfor %}`~

1. Add the `jinja.ext.do` extension to Jinja.  This enables `{% do ... %}` statements which execute a command for which the output should not be saved.  A useful example is appending to a list.  Since lists in Python return `None`, "None" would be written to the parsed jinja template in the following example: `{% set a_list = [] %}{{ a_list.append("foo") }}`.  Instead, one can now use do:
```jinja
{% set a_list = [] %}
{% do a_list.append("foo") %}
```

2. Lastly, this updates the `lambda` function for the `add_to_datetime` filter so any `SilentUndefined` input will return a `SilentUndefined`, preventing obscure failures.

This is needed for noaa-emc/global-workflow#2491
**Type of change**

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
<!-- If adding a new feature, was an accompanying test added? -->

- [x] pynorms
- [x] pytests

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published