### PR TITLE
Option to error on missing Jinja2 variables

### DIFF
--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -225,7 +225,7 @@ class Jinja:
         try:
             rendered = template.render(**self.data)
         except jinja2.UndefinedError as ee:
-            raise Exception(f"Undefined variable in Jinja2 template\n{ee}")
+            raise NameError(f"Undefined variable in Jinja2 template\n{ee}")
 
         return rendered
 

--- a/src/wxflow/yaml_file.py
+++ b/src/wxflow/yaml_file.py
@@ -156,7 +156,7 @@ def vanilla_yaml(ctx):
         return ctx
 
 
-def parse_j2yaml(path: str, data: Dict, searchpath: Union[str, List] = '/') -> Dict[str, Any]:
+def parse_j2yaml(path: str, data: Dict, searchpath: Union[str, List] = '/', allow_missing: bool = True) -> Dict[str, Any]:
     """
     Description
     -----------
@@ -171,6 +171,8 @@ def parse_j2yaml(path: str, data: Dict, searchpath: Union[str, List] = '/') -> D
         the context for jinja2 templating
     searchpath: str | List
         additional search paths for included jinja2 templates
+    allow_missing: bool
+        whether to allow missing variables in a jinja2 template or not
     Returns
     -------
     Dict[str, Any]
@@ -180,4 +182,4 @@ def parse_j2yaml(path: str, data: Dict, searchpath: Union[str, List] = '/') -> D
     if not os.path.exists(path):
         raise FileNotFoundError(f"Input j2yaml file {path} does not exist!")
 
-    return YAMLFile(data=Jinja(path, data, searchpath=searchpath).render)
+    return YAMLFile(data=Jinja(path, data, searchpath=searchpath, allow_missing=allow_missing).render)

--- a/tests/test_yaml_file.py
+++ b/tests/test_yaml_file.py
@@ -53,6 +53,14 @@ def test_yaml_file(tmp_path, create_template):
     assert yaml_in == conf
 
 
+def test_j2template_missing_var(tmp_path, create_template):
+
+    # Try to parse a j2yaml with an undefined variable (user)
+    os.environ['TMP_PATH'] = str(tmp_path)
+    with pytest.raises(NameError) as e_info:
+        data = {'current_cycle': datetime.now()}
+        conf = parse_j2yaml(path=str(tmp_path / 'j2tmpl.yaml'), data=data, allow_missing=False)
+
 def test_yaml_file_with_j2templates(tmp_path, create_template):
 
     # Set env. variable

--- a/tests/test_yaml_file.py
+++ b/tests/test_yaml_file.py
@@ -61,6 +61,7 @@ def test_j2template_missing_var(tmp_path, create_template):
         data = {'current_cycle': datetime.now()}
         conf = parse_j2yaml(path=str(tmp_path / 'j2tmpl.yaml'), data=data, allow_missing=False)
 
+
 def test_yaml_file_with_j2templates(tmp_path, create_template):
 
     # Set env. variable


### PR DESCRIPTION
**Description**

This allows a user to specify if they want to allow missing variables in a jinja2 template.  If `allow_missing == False`, a `NameError` will be raised with the name of the variable that is undefined.  The default is `True`, which is the current behavior.

**Type of change**

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**How Has This Been Tested?**

- [x] pynorms
- [x] pytests

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes