### PR TITLE
Resolving shell environment variables name space conflicts with parm

### DIFF
--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -3,6 +3,7 @@ import os
 import random
 from typing import Optional
 import subprocess
+import shutil
 from pathlib import Path
 from pprint import pprint
 from typing import Any, Dict, List, Union
@@ -111,8 +112,9 @@ class Configuration:
         runme = ''.join([f'source {s} ; ' for s in scripts])
         magic = f'--- ENVIRONMENT BEGIN {random.randint(0,64**5)} ---'
         runme += f'/bin/echo -n "{magic}" ; /usr/bin/env -0'
+        bash_path = shutil.which('bash')
         with open('/dev/null', 'w') as null:
-            env = subprocess.Popen(runme, shell=True, executable='/bin/bash', stdin=null.fileno(),
+            env = subprocess.Popen(runme, shell=True, executable=bash_path, stdin=null.fileno(),
                                    stdout=subprocess.PIPE)
             (out, err) = env.communicate()
         out = out.decode()

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -98,8 +98,11 @@ class Configuration:
     def _get_script_env(cls, scripts: List) -> Dict[str, Any]:
         default_env = cls._get_shell_env([])
         and_script_env = cls._get_shell_env(scripts)
-        diff_values_dict = {k: and_script_env[k] for k in default_env if k in and_script_env and default_env[k] != and_script_env[k]}
-        vars_just_in_script = set(set(and_script_env) - set(default_env)).union(set(diff_values_dict))
+        keys_in_scripts = set()
+        for script in scripts:
+            result = subprocess.run(['grep', '-o', '-E', '\\b(' + '|'.join(default_env.keys()) + ')\\b', script], stdout=subprocess.PIPE)
+            keys_in_scripts.update(result.stdout.decode().split())
+        vars_just_in_script = set(and_script_env) - set(default_env) | keys_in_scripts
         union_env = dict(default_env)
         union_env.update(and_script_env)
         return dict([(v, union_env[v]) for v in vars_just_in_script])

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -99,7 +99,8 @@ class Configuration:
         default_env = cls._get_shell_env([])
         and_script_env = cls._get_shell_env(scripts)
         keys_in_scripts = set()
-        regex_pattern = 'export\\s+\\b(' + '|'.join(map(re.escape, default_env.keys())) + ')(?==)'
+        #regex_pattern = 'export\\s+\\b(' + '|'.join(map(re.escape, default_env.keys())) + ')(?==)'
+        regex_pattern = '\\b(' + '|'.join(map(re.escape, default_env.keys())) + ')(?==)'
         for script in scripts:
             result = subprocess.run(['grep', '-o', '-P', regex_pattern, script], stdout=subprocess.PIPE)
             keys_in_scripts.update(result.stdout.decode().split())

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -81,8 +81,7 @@ class Configuration:
         if isinstance(files, (str, bytes)):
             files = [files]
         files = [self.find_config(file) for file in files]
-        config_dict = self._get_script_env(files)  # get the config dictionary from the config files
-        return cast_strdict_as_dtypedict(self._get_script_env(files, config_dict))
+        return cast_strdict_as_dtypedict(self._get_script_env(files))
 
     def print_config(self, files: Union[str, bytes, list]) -> None:
         """
@@ -96,12 +95,11 @@ class Configuration:
         pprint(config, width=4)
 
     @classmethod
-    def _get_script_env(cls, scripts: List, config_dict: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def _get_script_env(cls, scripts: List) -> Dict[str, Any]:
         default_env = cls._get_shell_env([])
         and_script_env = cls._get_shell_env(scripts)
-        if config_dict is not None:  # only update the environment with the config dictionary if it is provided
-            default_env = {k: v for k, v in default_env.items() if k in config_dict}
-        vars_just_in_script = set(and_script_env) - set(default_env)
+        diff_values_dict = {k: and_script_env[k] for k in default_env if k in and_script_env and default_env[k] != and_script_env[k]}
+        vars_just_in_script = set(set(and_script_env) - set(default_env)).union(set(diff_values_dict))
         union_env = dict(default_env)
         union_env.update(and_script_env)
         return dict([(v, union_env[v]) for v in vars_just_in_script])

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import random
+from typing import Optional
 import subprocess
 from pathlib import Path
 from pprint import pprint
@@ -79,7 +80,8 @@ class Configuration:
         if isinstance(files, (str, bytes)):
             files = [files]
         files = [self.find_config(file) for file in files]
-        return cast_strdict_as_dtypedict(self._get_script_env(files))
+        config_dict = self._get_script_env(files)  # get the config dictionary from the config files
+        return cast_strdict_as_dtypedict(self._get_script_env(files, config_dict))
 
     def print_config(self, files: Union[str, bytes, list]) -> None:
         """
@@ -93,9 +95,11 @@ class Configuration:
         pprint(config, width=4)
 
     @classmethod
-    def _get_script_env(cls, scripts: List) -> Dict[str, Any]:
+    def _get_script_env(cls, scripts: List, config_dict: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         default_env = cls._get_shell_env([])
         and_script_env = cls._get_shell_env(scripts)
+        if config_dict is not None:  # only update the environment with the config dictionary if it is provided
+            default_env = {k: v for k, v in default_env.items() if k in config_dict}
         vars_just_in_script = set(and_script_env) - set(default_env)
         union_env = dict(default_env)
         union_env.update(and_script_env)

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import random
-from typing import Optional
 import subprocess
 import shutil
 from pathlib import Path

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import re
 import random
 import shutil
 import subprocess
@@ -98,8 +99,9 @@ class Configuration:
         default_env = cls._get_shell_env([])
         and_script_env = cls._get_shell_env(scripts)
         keys_in_scripts = set()
+        regex_pattern = 'export\\s+\\b(' + '|'.join(map(re.escape, default_env.keys())) + ')(?==)'
         for script in scripts:
-            result = subprocess.run(['grep', '-o', '-P', '\\b(' + '|'.join(default_env.keys()) + ')(?==)', script], stdout=subprocess.PIPE)
+            result = subprocess.run(['grep', '-o', '-P', regex_pattern, script], stdout=subprocess.PIPE)
             keys_in_scripts.update(result.stdout.decode().split())
         vars_just_in_script = set(and_script_env) - set(default_env) | keys_in_scripts
         union_env = dict(default_env)

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -100,7 +100,7 @@ class Configuration:
         and_script_env = cls._get_shell_env(scripts)
         keys_in_scripts = set()
         for script in scripts:
-            result = subprocess.run(['grep', '-o', '-E', '\\b(' + '|'.join(default_env.keys()) + ')\\b', script], stdout=subprocess.PIPE)
+            result = subprocess.run(['grep', '-o', '-P', '\\b(' + '|'.join(default_env.keys()) + ')(?==)', script], stdout=subprocess.PIPE)
             keys_in_scripts.update(result.stdout.decode().split())
         vars_just_in_script = set(and_script_env) - set(default_env) | keys_in_scripts
         union_env = dict(default_env)

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -1,8 +1,8 @@
 import glob
 import os
 import random
-import subprocess
 import shutil
+import subprocess
 from pathlib import Path
 from pprint import pprint
 from typing import Any, Dict, List, Union

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -96,18 +96,14 @@ class Configuration:
 
     @classmethod
     def _get_script_env(cls, scripts: List) -> Dict[str, Any]:
+        varbles = dict()
         default_env = cls._get_shell_env([])
         and_script_env = cls._get_shell_env(scripts)
-        keys_in_scripts = set()
-        #regex_pattern = 'export\\s+\\b(' + '|'.join(map(re.escape, default_env.keys())) + ')(?==)'
-        regex_pattern = '\\b(' + '|'.join(map(re.escape, default_env.keys())) + ')(?==)'
-        for script in scripts:
-            result = subprocess.run(['grep', '-o', '-P', regex_pattern, script], stdout=subprocess.PIPE)
-            keys_in_scripts.update(result.stdout.decode().split())
-        vars_just_in_script = set(and_script_env) - set(default_env) | keys_in_scripts
-        union_env = dict(default_env)
-        union_env.update(and_script_env)
-        return dict([(v, union_env[v]) for v in vars_just_in_script])
+
+        for key, value in and_script_env.items():
+            if key not in default_env or default_env[key] != value:
+                varbles[key] = value
+        return varbles
 
     @staticmethod
     def _get_shell_env(scripts: List) -> Dict[str, Any]:

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -112,7 +112,7 @@ class Configuration:
         magic = f'--- ENVIRONMENT BEGIN {random.randint(0,64**5)} ---'
         runme += f'/bin/echo -n "{magic}" ; /usr/bin/env -0'
         with open('/dev/null', 'w') as null:
-            env = subprocess.Popen(runme, shell=True, stdin=null.fileno(),
+            env = subprocess.Popen(runme, shell=True, executable='/bin/bash' stdin=null.fileno(),
                                    stdout=subprocess.PIPE)
             (out, err) = env.communicate()
         out = out.decode()

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -112,7 +112,7 @@ class Configuration:
         magic = f'--- ENVIRONMENT BEGIN {random.randint(0,64**5)} ---'
         runme += f'/bin/echo -n "{magic}" ; /usr/bin/env -0'
         with open('/dev/null', 'w') as null:
-            env = subprocess.Popen(runme, shell=True, executable='/bin/bash' stdin=null.fileno(),
+            env = subprocess.Popen(runme, shell=True, executable='/bin/bash', stdin=null.fileno(),
                                    stdout=subprocess.PIPE)
             (out, err) = env.communicate()
         out = out.decode()

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -100,7 +100,7 @@ class Configuration:
         default_env = cls._get_shell_env([])
         and_script_env = cls._get_shell_env(scripts)
         if config_dict is not None:  # only update the environment with the config dictionary if it is provided
-            default_env = {k: v for k, v in default_env.items() if k in config_dict}
+            default_env = {kk: vv for kk, vv in default_env.items() if kk in config_dict}
         vars_just_in_script = set(and_script_env) - set(default_env)
         union_env = dict(default_env)
         union_env.update(and_script_env)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -159,9 +159,7 @@ def test_find_config(tmp_path, create_configs):
 def test_parse_config1(tmp_path, create_configs):
     cfg = Configuration(tmp_path)
     f0 = cfg.parse_config('config.file0')
-    print(f0)
-    assert 1 == 2
-    #assert file0_dict == f0
+    assert file0_dict == f0
 
 
 def test_parse_config2(tmp_path, create_configs):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -144,7 +144,7 @@ def test_configuration_config_dir(tmp_path, create_configs):
     assert cfg.config_dir == tmp_path
 
 
-@pytest.mark.skip(reason="fails in GH runner, passes on localhost")
+#@pytest.mark.skip(reason="fails in GH runner, passes on localhost")
 def test_configuration_config_files(tmp_path, create_configs):
     cfg = Configuration(tmp_path)
     config_files = [str(tmp_path / 'config.file0'), str(tmp_path / 'config.file1')]
@@ -157,14 +157,14 @@ def test_find_config(tmp_path, create_configs):
     assert str(tmp_path / 'config.file0') == file0
 
 
-@pytest.mark.skip(reason="fails in GH runner, passes on localhost")
+#@pytest.mark.skip(reason="fails in GH runner, passes on localhost")
 def test_parse_config1(tmp_path, create_configs):
     cfg = Configuration(tmp_path)
     f0 = cfg.parse_config('config.file0')
     assert file0_dict == f0
 
 
-@pytest.mark.skip(reason="fails in GH runner, passes on localhost")
+#@pytest.mark.skip(reason="fails in GH runner, passes on localhost")
 def test_parse_config2(tmp_path, create_configs):
     cfg = Configuration(tmp_path)
     ff = cfg.parse_config(['config.file0', 'config.file1'])

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -144,7 +144,6 @@ def test_configuration_config_dir(tmp_path, create_configs):
     assert cfg.config_dir == tmp_path
 
 
-@pytest.mark.skip(reason="fails in GH runner, passes on localhost")
 def test_configuration_config_files(tmp_path, create_configs):
     cfg = Configuration(tmp_path)
     config_files = [str(tmp_path / 'config.file0'), str(tmp_path / 'config.file1')]
@@ -157,14 +156,14 @@ def test_find_config(tmp_path, create_configs):
     assert str(tmp_path / 'config.file0') == file0
 
 
-@pytest.mark.skip(reason="fails in GH runner, passes on localhost")
 def test_parse_config1(tmp_path, create_configs):
     cfg = Configuration(tmp_path)
     f0 = cfg.parse_config('config.file0')
-    assert file0_dict == f0
+    print(f0)
+    assert 1 == 2
+    #assert file0_dict == f0
 
 
-@pytest.mark.skip(reason="fails in GH runner, passes on localhost")
 def test_parse_config2(tmp_path, create_configs):
     cfg = Configuration(tmp_path)
     ff = cfg.parse_config(['config.file0', 'config.file1'])


### PR DESCRIPTION
**Description**

This PR updates the instantiation of the **Configuration Class** of **wxflow** in order to resolve the namespaces **_clashes_** between the environment variables in shell that launches `setup_xml.py` and the values used in config parm variables.

With this update the namespaces between the shell environment variables and the variables in parm files used by the **Configuration Class** are preserved.  A Unit Test demonstrating this can be found [here](https://github.com/TerrenceMcGuinness-NOAA/global-workflow/blob/d0bfa61c9719bf072d9f0d428b929da53898bf15/ci/scripts/tests/test_setup.py#L27).

For example, if the environment variable ACCOUNT is set in the shell that `setup_expt.py` is launched from, it would would fail as that variable is also used in template of `config.base`.  Correspondingly, if `setup_xml.py` was executed with ACCOUNT set in the shell it would populate the XML file with UNKOWN without erroring.  With this update the value in the XML file would be set he value designated in the corresponding instantiated **parm** file `config.base`.

The Unit Tests specified below shows this failure does not occure and the updates are used in Test [PR 2581](https://github.com/NOAA-EMC/global-workflow/pull/2581)

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
- [x] pynorms
- [x] pytests

This PR Branch was incorporated into Global-Workflow [PR 2581](https://github.com/NOAA-EMC/global-workflow/pull/2581) [Unit Tests](https://github.com/TerrenceMcGuinness-NOAA/global-workflow/blob/ci_unit-tests/ci/scripts/tests/test_setup.py) using [GitHub Actions](https://github.com/TerrenceMcGuinness-NOAA/global-workflow/blob/ci_unit-tests/.github/workflows/ci-unit_tests.yaml).
Here are the [results](https://github.com/NOAA-EMC/global-workflow/actions/runs/9342319383/job/25710250521) of running the Unit Tests from GitHub Actions. PR 2581 also does full CI run throughs using this update in the Configuration Class.

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
