### PR TITLE
Create task_config member variable upon initialization

### DIFF
--- a/src/wxflow/task.py
+++ b/src/wxflow/task.py
@@ -30,7 +30,7 @@ class Task:
         """
 
         # Store the config and arguments as attributes of the object
-        self.config = AttrDict(config)
+        self._config = AttrDict(config)
 
         for arg in args:
             setattr(self, str(arg), arg)
@@ -39,13 +39,13 @@ class Task:
             setattr(self, key, value)
 
         # Pull out basic runtime keys values from config into its own runtime config
-        self.runtime_config = AttrDict()
+        self._runtime_config = AttrDict()
         runtime_keys = ['PDY', 'cyc', 'DATA', 'RUN', 'CDUMP']  # TODO: eliminate CDUMP and use RUN instead
         for kk in runtime_keys:
             try:
-                self.runtime_config[kk] = config[kk]
+                self._runtime_config[kk] = config[kk]
                 logger.debug(f'Deleting runtime_key {kk} from config')
-                del self.config[kk]
+                del self._config[kk]
             except KeyError:
                 raise KeyError(f"Encountered an unreferenced runtime_key {kk} in 'config'")
 
@@ -53,12 +53,16 @@ class Task:
         # can be constructed here
 
         # Construct the current cycle datetime object
-        self.runtime_config['current_cycle'] = add_to_datetime(self.runtime_config['PDY'], to_timedelta(f"{self.runtime_config.cyc}H"))
-        logger.debug(f"current cycle: {self.runtime_config['current_cycle']}")
+        self._runtime_config['current_cycle'] = add_to_datetime(self._runtime_config['PDY'], to_timedelta(f"{self._runtime_config.cyc}H"))
+        logger.debug(f"current cycle: {self._runtime_config['current_cycle']}")
 
         # Construct the previous cycle datetime object
-        self.runtime_config['previous_cycle'] = add_to_datetime(self.runtime_config.current_cycle, -to_timedelta(f"{self.config['assim_freq']}H"))
-        logger.debug(f"previous cycle: {self.runtime_config['previous_cycle']}")
+        self._runtime_config['previous_cycle'] = add_to_datetime(self._runtime_config.current_cycle, -to_timedelta(f"{self._config['assim_freq']}H"))
+        logger.debug(f"previous cycle: {self._runtime_config['previous_cycle']}")
+
+        # Create task_config which combines the contents of config and runtime_config. 
+        # Only task_config should be accessed from this point on.
+        self.task_config = AttrDict(**self._config, **self._runtime_config
 
         pass
 

--- a/src/wxflow/task.py
+++ b/src/wxflow/task.py
@@ -38,7 +38,7 @@ class Task:
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-        # Create task_config with everything that is inside _config and whatever the user chooses to 
+        # Create task_config with everything that is inside _config and whatever the user chooses to
         # extend it with when initializing a child subclass of Task. Only task_config should be referenced
         # in any application, not _config.
         self.task_config = self._config.copy

--- a/src/wxflow/task.py
+++ b/src/wxflow/task.py
@@ -38,12 +38,15 @@ class Task:
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-        # Pull out basic runtime keys values from config into its own runtime config
-        self._runtime_config = AttrDict()
+        # Create task_config with everything that is inside _config and whatever the user chooses to 
+        # extend it with when initializing a child subclass of Task. Only task_config should be referenced
+        # in any application, not _config.
+        self.task_config = self._config.copy
+
+        # Pull out basic runtime keys values from config into its own runti
         runtime_keys = ['PDY', 'cyc', 'DATA', 'RUN', 'CDUMP']  # TODO: eliminate CDUMP and use RUN instead
         for kk in runtime_keys:
             try:
-                self._runtime_config[kk] = config[kk]
                 logger.debug(f'Deleting runtime_key {kk} from config')
                 del self._config[kk]
             except KeyError:
@@ -53,16 +56,12 @@ class Task:
         # can be constructed here
 
         # Construct the current cycle datetime object
-        self._runtime_config['current_cycle'] = add_to_datetime(self._runtime_config['PDY'], to_timedelta(f"{self._runtime_config.cyc}H"))
-        logger.debug(f"current cycle: {self._runtime_config['current_cycle']}")
+        self.task_config['current_cycle'] = add_to_datetime(self.task_config['PDY'], to_timedelta(f"{self.task_config.cyc}H"))
+        logger.debug(f"current cycle: {self.task_config['current_cycle']}")
 
         # Construct the previous cycle datetime object
-        self._runtime_config['previous_cycle'] = add_to_datetime(self._runtime_config.current_cycle, -to_timedelta(f"{self._config['assim_freq']}H"))
-        logger.debug(f"previous cycle: {self._runtime_config['previous_cycle']}")
-
-        # Create task_config which combines the contents of config and runtime_config.
-        # Only task_config should be accessed from this point on.
-        self.task_config = AttrDict(**self._config, **self._runtime_config)
+        self.task_config['previous_cycle'] = add_to_datetime(self.task_config.current_cycle, -to_timedelta(f"{self._config['assim_freq']}H"))
+        logger.debug(f"previous cycle: {self.task_config['previous_cycle']}")
 
         pass
 

--- a/src/wxflow/task.py
+++ b/src/wxflow/task.py
@@ -62,7 +62,7 @@ class Task:
 
         # Create task_config which combines the contents of config and runtime_config. 
         # Only task_config should be accessed from this point on.
-        self.task_config = AttrDict(**self._config, **self._runtime_config
+        self.task_config = AttrDict(**self._config, **self._runtime_config)
 
         pass
 

--- a/src/wxflow/task.py
+++ b/src/wxflow/task.py
@@ -41,7 +41,7 @@ class Task:
         # Create task_config with everything that is inside _config and whatever the user chooses to
         # extend it with when initializing a child subclass of Task. Only task_config should be referenced
         # in any application, not _config.
-        self.task_config = self._config.copy
+        self.task_config = self._config.copy()
 
         # Any other composite runtime variables that may be needed for the duration of the task
         # can be constructed here

--- a/src/wxflow/task.py
+++ b/src/wxflow/task.py
@@ -60,7 +60,7 @@ class Task:
         self._runtime_config['previous_cycle'] = add_to_datetime(self._runtime_config.current_cycle, -to_timedelta(f"{self._config['assim_freq']}H"))
         logger.debug(f"previous cycle: {self._runtime_config['previous_cycle']}")
 
-        # Create task_config which combines the contents of config and runtime_config. 
+        # Create task_config which combines the contents of config and runtime_config.
         # Only task_config should be accessed from this point on.
         self.task_config = AttrDict(**self._config, **self._runtime_config)
 

--- a/src/wxflow/task.py
+++ b/src/wxflow/task.py
@@ -47,7 +47,7 @@ class Task:
         # can be constructed here
 
         # Construct the current cycle datetime object
-        self.task_config['current_cycle'] = add_to_datetime(self.task_config['PDY'], to_timedelta(f"{self.task_config.cyc}H"))
+        self.task_config['current_cycle'] = add_to_datetime(self._config['PDY'], to_timedelta(f"{self._config.cyc}H"))
         logger.debug(f"current cycle: {self.task_config['current_cycle']}")
 
         # Construct the previous cycle datetime object

--- a/src/wxflow/task.py
+++ b/src/wxflow/task.py
@@ -43,15 +43,6 @@ class Task:
         # in any application, not _config.
         self.task_config = self._config.copy
 
-        # Pull out basic runtime keys values from config into its own runti
-        runtime_keys = ['PDY', 'cyc', 'DATA', 'RUN', 'CDUMP']  # TODO: eliminate CDUMP and use RUN instead
-        for kk in runtime_keys:
-            try:
-                logger.debug(f'Deleting runtime_key {kk} from config')
-                del self._config[kk]
-            except KeyError:
-                raise KeyError(f"Encountered an unreferenced runtime_key {kk} in 'config'")
-
         # Any other composite runtime variables that may be needed for the duration of the task
         # can be constructed here
 


### PR DESCRIPTION
**Description**

This PR creates the `task_config` member variable in the `Task` `__init__` function. Normally it is created upon initialization of a child subclasses of `Task`, but since it is expected to exist for every application of the `Task` class I've seen so far, it's better to create it at initialization.

This PR also eliminates `runtime_config`, since it's mostly redundant and renames the `config` member variable with a leading underscores to emphasize that they should be treated as private. 

This PR is a companion to Global Workflow PR [#2654](https://github.com/NOAA-EMC/global-workflow/pull/2654) which replaces any reference to `config` or `runtime_config` member variables with `task_config`.

**Type of change**

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
<!-- If adding a new feature, was an accompanying test added? -->

- [X] pynorms
- [X] pytests
- [X] GDASApp j-job tests
- [X] Cycling experiment on Orion with Global Workflow

**Checklist**

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
