### PR TITLE
Create replace_tmpl filter for Jinja2

### DIFF
--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -111,6 +111,7 @@ class Jinja:
         getenv: read variable from environment if defined, else UNDEFINED
         to_timedelta: convert a string to a timedelta object
         add_to_datetime: add time to a datetime, return new datetime object
+        replace_tmpl: replace substrings of an input string with replacements specified by an input dictionary
 
         The Expression Statement extension "jinja2.ext.do", which enables
             {% do ... %} statements.  These are useful for appending to lists.

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Union
 import jinja2
 from markupsafe import Markup
 
-from .template import (replace_tmpl)
+from .template import replace_tmpl
 from .timetools import (add_to_datetime, strftime, to_fv3time, to_isotime,
                         to_julian, to_timedelta, to_YMD, to_YMDH)
 

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -1,11 +1,11 @@
 import os
 import sys
+from functools import reduce
 from pathlib import Path
 from typing import Dict, List, Union
 
 import jinja2
 from markupsafe import Markup
-from functools import reduce
 
 from .timetools import (add_to_datetime, strftime, to_fv3time, to_isotime,
                         to_julian, to_timedelta, to_YMD, to_YMDH)

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -6,9 +6,9 @@ from typing import Dict, List, Union
 import jinja2
 from markupsafe import Markup
 
+from .template import (replace_tmpl)
 from .timetools import (add_to_datetime, strftime, to_fv3time, to_isotime,
                         to_julian, to_timedelta, to_YMD, to_YMDH)
-from .template import (replace_tmpl)
 
 __all__ = ['Jinja']
 
@@ -148,7 +148,7 @@ class Jinja:
                 else dt if isinstance(dt, SilentUndefined) else delta)
         env.filters["to_timedelta"] = lambda delta_str: to_timedelta(delta_str) if not isinstance(delta_str, SilentUndefined) else delta_str
         env.filters["replace_tmpl"] = lambda string, tmpl_dict: replace_tmpl(string, tmpl_dict)
-        
+
         # Add any additional filters
         if filters is not None:
             for filter_name, filter_func in filters.items():

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -5,8 +5,8 @@ from typing import Dict, List, Union
 
 import jinja2
 from markupsafe import Markup
+from functools import reduce
 
-from .template import replace_tmpl
 from .timetools import (add_to_datetime, strftime, to_fv3time, to_isotime,
                         to_julian, to_timedelta, to_YMD, to_YMDH)
 
@@ -147,7 +147,7 @@ class Jinja:
                 if not (isinstance(dt, SilentUndefined) or isinstance(delta, SilentUndefined))
                 else dt if isinstance(dt, SilentUndefined) else delta)
         env.filters["to_timedelta"] = lambda delta_str: to_timedelta(delta_str) if not isinstance(delta_str, SilentUndefined) else delta_str
-        env.filters["replace_tmpl"] = lambda string, tmpl_dict: replace_tmpl(string, tmpl_dict)
+        env.filters["replace_tmpl"] = lambda string, tmpl_dict: reduce(lambda ss, kk: ss.replace(kk, tmpl_dict[kk]), tmpl_dict, string)
 
         # Add any additional filters
         if filters is not None:

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -8,6 +8,7 @@ from markupsafe import Markup
 
 from .timetools import (add_to_datetime, strftime, to_fv3time, to_isotime,
                         to_julian, to_timedelta, to_YMD, to_YMDH)
+from .template import (replace_tmpl)
 
 __all__ = ['Jinja']
 
@@ -146,7 +147,8 @@ class Jinja:
                 if not (isinstance(dt, SilentUndefined) or isinstance(delta, SilentUndefined))
                 else dt if isinstance(dt, SilentUndefined) else delta)
         env.filters["to_timedelta"] = lambda delta_str: to_timedelta(delta_str) if not isinstance(delta_str, SilentUndefined) else delta_str
-
+        env.filters["replace_tmpl"] = lambda string, tmpl_dict: replace_tmpl(string, tmpl_dict)
+        
         # Add any additional filters
         if filters is not None:
             for filter_name, filter_func in filters.items():

--- a/src/wxflow/task.py
+++ b/src/wxflow/task.py
@@ -41,7 +41,7 @@ class Task:
         # Create task_config with everything that is inside _config and whatever the user chooses to
         # extend it with when initializing a child subclass of Task. Only task_config should be referenced
         # in any application, not _config.
-        self.task_config = self._config.copy()
+        self.task_config = self._config.deepcopy()
 
         # Any other composite runtime variables that may be needed for the duration of the task
         # can be constructed here

--- a/src/wxflow/template.py
+++ b/src/wxflow/template.py
@@ -189,3 +189,12 @@ def is_single_type_or_string(s):
         return True
     else:
         return False
+
+def replace_tmpl(string, tmpl_dict):
+    """
+        Replace substrings of input string using  input dictionary.
+    """
+
+    for key in tmpl_dict:
+        string = string.replace(key, tmpl_dict[key])
+    return string

--- a/src/wxflow/template.py
+++ b/src/wxflow/template.py
@@ -189,13 +189,3 @@ def is_single_type_or_string(s):
         return True
     else:
         return False
-
-
-def replace_tmpl(string, tmpl_dict):
-    """
-        Replace substrings of input string using  input dictionary.
-    """
-
-    for key in tmpl_dict:
-        string = string.replace(key, tmpl_dict[key])
-    return string

--- a/src/wxflow/template.py
+++ b/src/wxflow/template.py
@@ -190,6 +190,7 @@ def is_single_type_or_string(s):
     else:
         return False
 
+
 def replace_tmpl(string, tmpl_dict):
     """
         Replace substrings of input string using  input dictionary.

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import jinja2
 import pytest
 
 from wxflow import Jinja, to_isotime
@@ -29,6 +30,10 @@ def test_render_stream():
     j = Jinja(j2tmpl, data, allow_missing=False)
     assert j.render == f"Hello Jane! How are you? It is: {to_isotime(current_date)}"
 
+    tmpl_dict = {"{{ name }}": "Jane", "{{ greeting }}": "How are you?", "{{ current_date | to_isotime }}": to_isotime(current_date)}
+    env = Jinja.get_set_env(jinja2.BaseLoader())
+    assert env.filters['replace_tmpl'](j2tmpl, tmpl_dict) == f"Hello Jane! How are you? It is: {to_isotime(current_date)}"
+                            
 
 def test_render_file(tmp_path, create_template):
 

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -31,9 +31,11 @@ def test_render_stream():
     assert j.render == f"Hello Jane! How are you? It is: {to_isotime(current_date)}"
 
     tmpl_dict = {"{{ name }}": "Jane", "{{ greeting }}": "How are you?", "{{ current_date | to_isotime }}": to_isotime(current_date)}
-    env = Jinja.get_set_env(jinja2.BaseLoader())
+    j = Jinja(j2tmpl, data, allow_missing=False)
+    loader = jinja2.BaseLoader()
+    env = j.get_set_env(loader)
     assert env.filters['replace_tmpl'](j2tmpl, tmpl_dict) == f"Hello Jane! How are you? It is: {to_isotime(current_date)}"
-                            
+
 
 def test_render_file(tmp_path, create_template):
 

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -48,6 +48,12 @@ def test_render_file(tmp_path, create_template):
     j = Jinja(str(file_path), data, allow_missing=False)
     assert j.render == f"Hello Jane! How are you? It is: {to_isotime(current_date)}"
 
+    tmpl_dict = {"{{ name }}": "Jane", "{{ greeting }}": "How are you?", "{{ current_date | to_isotime }}": to_isotime(current_date)}
+    j = Jinja(str(file_path), data, allow_missing=False)
+    loader = jinja2.BaseLoader()
+    env = j.get_set_env(loader)
+    assert env.filters['replace_tmpl'](j2tmpl, tmpl_dict) == f"Hello Jane! How are you? It is: {to_isotime(current_date)}"
+
 
 def test_include(tmp_path, create_template):
 


### PR DESCRIPTION
**Description**

This PR adds a filter for Jinja2 rendering called replace_tmpl that takes a string and replaces substrings defined in an input dictionary. The motivation is for when we want to replace multiple substrings in a template in the Global Workflow.

This PR also changes the copy() method that creates task_config in the Task class to deepcopy(), since in at least one case in the Global Workflow, a task_config key points to another dictionary.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**

ATM JJOB tests in GDASApp on Orion

- [X] pynorms
- [X] pytests

**Checklist**

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
