### PR TITLE
Parse comma-separated list as python list

### DIFF
--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -172,7 +172,7 @@ def cast_as_dtype(string: str) -> Union[str, int, float, bool, Any]:
 
     if ',' in string:
         # Convert comma-separated list to python list
-        return [ cast_as_dtype(elem.strip()) for elem in string.split(',') ]
+        return [cast_as_dtype(elem.strip()) for elem in string.split(',')]
 
     def _cast_or_not(to_type: Any, string: str):
         try:

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -170,6 +170,10 @@ def cast_as_dtype(string: str) -> Union[str, int, float, bool, Any]:
     BOOLS = ['n', 'no', 'f', 'false', '.f.', '.false.'] + TRUTHS
     BOOLS = [x.upper() for x in BOOLS] + BOOLS + ['Yes', 'No', 'True', 'False']
 
+    if ',' in string:
+        # Convert comma-separated list to python list
+        return [ cast_as_dtype(elem.strip()) for elem in string.split(',') ]
+
     def _cast_or_not(to_type: Any, string: str):
         try:
             return to_type(string)
@@ -187,9 +191,6 @@ def cast_as_dtype(string: str) -> Union[str, int, float, bool, Any]:
     except Exception as exc:
         if string in BOOLS:  # Likely a boolean, convert to True/False
             return _true_or_not(string)
-        elif ',' in string:
-            # Convert comma-separated list to python list
-            return [ cast_as_dtype(elem) for elem in string.split(',') ]
         elif '.' in string:  # Likely a number and that too a float
             return _cast_or_not(float, string)
         else:  # Still could be a number, may be an integer

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -187,9 +187,9 @@ def cast_as_dtype(string: str) -> Union[str, int, float, bool, Any]:
     except Exception as exc:
         if string in BOOLS:  # Likely a boolean, convert to True/False
             return _true_or_not(string)
-        elif string.startswith('(') and string.endswith(')'):
-            # Convert bash array to python array
-            return [ cast_as_dtype(elem) for elem in string[1:-1].split() ]
+        elif ',' in string:
+            # Convert comma-separated list to python list
+            return [ cast_as_dtype(elem) for elem in string.split(',') ]
         elif '.' in string:  # Likely a number and that too a float
             return _cast_or_not(float, string)
         else:  # Still could be a number, may be an integer

--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -156,21 +156,23 @@ def cast_strdict_as_dtypedict(ctx: Dict[str, str]) -> Dict[str, Any]:
 def cast_as_dtype(string: str) -> Union[str, int, float, bool, Any]:
     """
     Cast a value into known datatype
+
     Parameters
     ----------
     string: str
+
     Returns
     -------
-    value : str or int or float or datetime
+    value : str, int, float, bool or datetime; or List of these
             default: str
     """
     TRUTHS = ['y', 'yes', 't', 'true', '.t.', '.true.']
     BOOLS = ['n', 'no', 'f', 'false', '.f.', '.false.'] + TRUTHS
     BOOLS = [x.upper() for x in BOOLS] + BOOLS + ['Yes', 'No', 'True', 'False']
 
-    def _cast_or_not(type: Any, string: str):
+    def _cast_or_not(to_type: Any, string: str):
         try:
-            return type(string)
+            return to_type(string)
         except ValueError:
             return string
 
@@ -185,6 +187,9 @@ def cast_as_dtype(string: str) -> Union[str, int, float, bool, Any]:
     except Exception as exc:
         if string in BOOLS:  # Likely a boolean, convert to True/False
             return _true_or_not(string)
+        elif string.startswith('(') and string.endswith(')'):
+            # Convert bash array to python array
+            return [ cast_as_dtype(elem) for elem in string[1:-1].split() ]
         elif '.' in string:  # Likely a number and that too a float
             return _cast_or_not(float, string)
         else:  # Still could be a number, may be an integer

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -30,6 +30,11 @@ export SOME_BOOL3=.T.
 export SOME_BOOL4=NO
 export SOME_BOOL5=.false.
 export SOME_BOOL6=.F.
+export SOME_LIST1="3, 15, -999"
+export SOME_LIST2="0.2,3.5,-9999."
+export SOME_LIST3="20221225, 202212251845"
+export SOME_LIST4="YES, .false., .T."
+export SOME_LIST5="0.2, 15, 20221225, NO"
 """
 
 file1 = """#!/bin/bash
@@ -60,7 +65,12 @@ file0_dict = {
     'SOME_BOOL3': True,
     'SOME_BOOL4': False,
     'SOME_BOOL5': False,
-    'SOME_BOOL6': False
+    'SOME_BOOL6': False,
+    'SOME_LIST1': [3, 15, -999],
+    'SOME_LIST2': [0.2,3.5,-9999.],
+    'SOME_LIST3': [datetime(2022, 12, 25, 0, 0, 0), datetime(2022, 12, 25, 18, 45, 0)],
+    'SOME_LIST4': [True, False, True],
+    'SOME_LIST5': [0.2, 15, datetime(2022, 12, 25, 0, 0, 0), False],
 }
 
 file0_dict_set_envvar = file0_dict.copy()
@@ -107,6 +117,14 @@ datetime_dtypes = [
     ('20221215T1830Z', datetime(2022, 12, 15, 18, 30, 0)),
 ]
 
+list_dtypes = [
+    ('3, 15, -999', [3, 15, -999]),
+    ('0.2,3.5,-9999.', [0.2,3.5,-9999.]),
+    ('20221215,20221215T1830Z', [datetime(2022, 12, 15, 0, 0, 0), datetime(2022, 12, 15, 18, 30, 0)]),
+    ('YES, .false., .T.', [True, False, True]),
+    ('0.2, 15, 20221225, NO', [0.2, 15, datetime(2022, 12, 25, 0, 0, 0), False]),
+]
+
 
 def evaluate(dtypes):
     for pair in dtypes:
@@ -132,6 +150,9 @@ def test_cast_as_dtype_bool():
 
 def test_cast_as_dtype_datetimes():
     evaluate(datetime_dtypes)
+
+def test_cast_as_dtype_list():
+    evaluate(list_dtypes)
 
 
 @pytest.fixture

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -34,7 +34,7 @@ export SOME_LIST1="3, 15, -999"
 export SOME_LIST2="0.2,3.5,-9999."
 export SOME_LIST3="20221225, 202212251845"
 export SOME_LIST4="YES, .false., .T."
-export SOME_LIST5="0.2, 15, 20221225, NO"
+export SOME_LIST5="0.2, test_str, 15, 20221225, NO"
 """
 
 file1 = """#!/bin/bash
@@ -70,7 +70,7 @@ file0_dict = {
     'SOME_LIST2': [0.2, 3.5, -9999.],
     'SOME_LIST3': [datetime(2022, 12, 25, 0, 0, 0), datetime(2022, 12, 25, 18, 45, 0)],
     'SOME_LIST4': [True, False, True],
-    'SOME_LIST5': [0.2, 15, datetime(2022, 12, 25, 0, 0, 0), False],
+    'SOME_LIST5': [0.2, 'test_str', 15, datetime(2022, 12, 25, 0, 0, 0), False],
 }
 
 file0_dict_set_envvar = file0_dict.copy()
@@ -122,7 +122,7 @@ list_dtypes = [
     ('0.2,3.5,-9999.', [0.2, 3.5, -9999.]),
     ('20221215,20221215T1830Z', [datetime(2022, 12, 15, 0, 0, 0), datetime(2022, 12, 15, 18, 30, 0)]),
     ('YES, .false., .T.', [True, False, True]),
-    ('0.2, 15, 20221225, NO', [0.2, 15, datetime(2022, 12, 25, 0, 0, 0), False]),
+    ('0.2, test_str, 15, 20221225, NO', [0.2, 'test_str', 15, datetime(2022, 12, 25, 0, 0, 0), False]),
 ]
 
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -67,7 +67,7 @@ file0_dict = {
     'SOME_BOOL5': False,
     'SOME_BOOL6': False,
     'SOME_LIST1': [3, 15, -999],
-    'SOME_LIST2': [0.2,3.5,-9999.],
+    'SOME_LIST2': [0.2, 3.5, -9999.],
     'SOME_LIST3': [datetime(2022, 12, 25, 0, 0, 0), datetime(2022, 12, 25, 18, 45, 0)],
     'SOME_LIST4': [True, False, True],
     'SOME_LIST5': [0.2, 15, datetime(2022, 12, 25, 0, 0, 0), False],
@@ -119,7 +119,7 @@ datetime_dtypes = [
 
 list_dtypes = [
     ('3, 15, -999', [3, 15, -999]),
-    ('0.2,3.5,-9999.', [0.2,3.5,-9999.]),
+    ('0.2,3.5,-9999.', [0.2, 3.5, -9999.]),
     ('20221215,20221215T1830Z', [datetime(2022, 12, 15, 0, 0, 0), datetime(2022, 12, 15, 18, 30, 0)]),
     ('YES, .false., .T.', [True, False, True]),
     ('0.2, 15, 20221225, NO', [0.2, 15, datetime(2022, 12, 25, 0, 0, 0), False]),
@@ -150,6 +150,7 @@ def test_cast_as_dtype_bool():
 
 def test_cast_as_dtype_datetimes():
     evaluate(datetime_dtypes)
+
 
 def test_cast_as_dtype_list():
     evaluate(list_dtypes)


### PR DESCRIPTION
**Description**
Adds parsing of a comma-separated list to a python list to Configuration.

In support of NOAA-EMC/global-workflow#2274

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
- [x] pynorms
- [x] pytests

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
