### PR TITLE
Remove empty elements from comma-separated list

### DIFF
--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -172,7 +172,7 @@ def cast_as_dtype(string: str) -> Union[str, int, float, bool, Any]:
 
     if ',' in string:
         # Convert comma-separated list to python list
-        return [cast_as_dtype(elem.strip()) for elem in string.split(',')]
+        return [cast_as_dtype(elem.strip()) for elem in string.split(',') if elem.strip() != '']
 
     def _cast_or_not(to_type: Any, string: str):
         try:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -32,7 +32,7 @@ export SOME_BOOL5=.false.
 export SOME_BOOL6=.F.
 export SOME_LIST1="3, 15, -999"
 export SOME_LIST2="0.2,3.5,-9999."
-export SOME_LIST3="20221225, 202212251845"
+export SOME_LIST3="20221225, 202212251845,"
 export SOME_LIST4="YES, .false., .T."
 export SOME_LIST5="0.2, test_str, 15, 20221225, NO"
 """


### PR DESCRIPTION
**Description**

Updates the list parsing in Configuration to remove empty strings from the comma-separated list. This will allow creating a single-element list by appending a `,` after the element, as well as just relax syntax on lists by ignore a trailing `,`.

Refs: NOAA-EMC/global-workflow#2795

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [x] pynorms
- [x] pytests

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
