### PR TITLE
Log exceptions and fix erroneous handling

### DIFF
--- a/src/wxflow/configuration.py
+++ b/src/wxflow/configuration.py
@@ -188,7 +188,7 @@ def cast_as_dtype(string: str) -> Union[str, int, float, bool, Any]:
 
     try:
         return to_datetime(string)  # Try as a datetime
-    except Exception as exc:
+    except Exception:
         if string in BOOLS:  # Likely a boolean, convert to True/False
             return _true_or_not(string)
         elif '.' in string:  # Likely a number and that too a float

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -84,9 +84,9 @@ class FileHandler:
                 try:
                     cp(src, dest)
                     logger.info(f'Copied {src} to {dest}')
-                except Exception:
+                except Exception as ee:
                     logger.exception(f"Error copying {src} to {dest}")
-                    raise OSError(f"Error copying {src} to {dest}")
+                    raise ee
             else:
                 if required:
                     logger.exception(f"Source file '{src}' does not exist and is required, ABORT!")
@@ -107,6 +107,6 @@ class FileHandler:
             try:
                 mkdir(dd)
                 logger.info(f'Created {dd}')
-            except Exception:
+            except Exception as ee:
                 logger.exception(f"Error creating directory {dd}")
-                raise OSError(f"\nError creating directory {dd}")
+                raise ee

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -84,9 +84,9 @@ class FileHandler:
                 try:
                     cp(src, dest)
                     logger.info(f'Copied {src} to {dest}')
-                except Exception as ee:
+                except Exception:
                     logger.exception(f"Error copying {src} to {dest}")
-                    raise OSError(str(ee), f"\nError copying {src} to {dest}")
+                    raise OSError(f"Error copying {src} to {dest}")
             else:
                 if required:
                     logger.exception(f"Source file '{src}' does not exist and is required, ABORT!")
@@ -107,6 +107,6 @@ class FileHandler:
             try:
                 mkdir(dd)
                 logger.info(f'Created {dd}')
-            except Exception as ee:
+            except Exception:
                 logger.exception(f"Error creating directory {dd}")
-                raise OSError(str(ee), f"\nError creating directory {dd}")
+                raise OSError(f"\nError creating directory {dd}")

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -86,7 +86,7 @@ class FileHandler:
                     logger.info(f'Copied {src} to {dest}')
                 except Exception as ee:
                     logger.exception(f"Error copying {src} to {dest}")
-                    raise ee(f"Error copying {src} to {dest}")
+                    raise OSError(str(ee), f"\nError copying {src} to {dest}")
             else:
                 if required:
                     logger.exception(f"Source file '{src}' does not exist and is required, ABORT!")
@@ -109,4 +109,4 @@ class FileHandler:
                 logger.info(f'Created {dd}')
             except Exception as ee:
                 logger.exception(f"Error creating directory {dd}")
-                raise ee(f"Error creating directory {dd}")
+                raise OSError(str(ee), f"\nError creating directory {dd}")

--- a/src/wxflow/fsutils.py
+++ b/src/wxflow/fsutils.py
@@ -108,7 +108,10 @@ def cp(source: str, target: str) -> None:
     try:
         shutil.copy2(source, target)
     except OSError:
-        raise OSError(f"unable to copy {source} to {target}")
+        raise OSError(f"Unable to copy {source} to {target}")
+    except Exception as ee:
+        logger.exception(f"An unknown error occurred while copying {source} to {target}")
+        raise ee
 
 
 # Group ID number for a given group name

--- a/src/wxflow/fsutils.py
+++ b/src/wxflow/fsutils.py
@@ -109,8 +109,6 @@ def cp(source: str, target: str) -> None:
         shutil.copy2(source, target)
     except OSError:
         raise OSError(f"unable to copy {source} to {target}")
-    except Exception as exc:
-        raise Exception(exc)
 
 
 # Group ID number for a given group name

--- a/src/wxflow/schema.py
+++ b/src/wxflow/schema.py
@@ -661,7 +661,8 @@ class Schema(object):
                                 sub_schema, is_main_schema=False, description=_get_key_description(key)
                             )
                             if isinstance(key, Optional) and hasattr(key, "default"):
-                                expanded_schema[key_name]["default"] = _to_json_type(_invoke_with_optional_kwargs(key.default, **kwargs) if callable(key.default) else key.default)  # nopep8
+                                expanded_schema[key_name]["default"] = (_to_json_type(_invoke_with_optional_kwargs(key.default, **kwargs)
+                                                                        if callable(key.default) else key.default))
                         elif isinstance(key_name, Or):
                             # JSON schema does not support having a key named one name or another, so we just add both options
                             # This is less strict because we cannot enforce that one or the other is required

--- a/src/wxflow/sqlitedb.py
+++ b/src/wxflow/sqlitedb.py
@@ -35,10 +35,7 @@ class SQLiteDB:
 
         """
 
-        try:
-            self.connection = sqlite3.connect(self.db_name)
-        except sqlite3.OperationalError as exc:
-            raise sqlite3.OperationalError(exc)
+        self.connection = sqlite3.connect(self.db_name)
 
     def disconnect(self) -> None:
         """
@@ -116,7 +113,7 @@ class SQLiteDB:
             columns = [column[1] for column in cursor.fetchall()]
             if column_name not in columns:
                 raise ValueError(f"Column '{column_name}' does not exist in table '{table_name}'")
-            raise sqlite3.OperationalError(exc)
+            raise sqlite3.OperationalError(str(exc))
 
     def update_data(
         self,

--- a/src/wxflow/sqlitedb.py
+++ b/src/wxflow/sqlitedb.py
@@ -1,6 +1,6 @@
 import sqlite3
-from typing import Any, List, Optional, Tuple
 from logging import getLogger
+from typing import Any, List, Optional, Tuple
 
 __all__ = ["SQLiteDB"]
 

--- a/src/wxflow/sqlitedb.py
+++ b/src/wxflow/sqlitedb.py
@@ -107,13 +107,13 @@ class SQLiteDB:
         try:
             query = f"ALTER TABLE {table_name} DROP COLUMN {column_name}"
             self.execute_query(query)
-        except sqlite3.OperationalError as exc:
+        except sqlite3.OperationalError:
             query = f"PRAGMA table_info({table_name})"
             cursor = self.execute_query(query)
             columns = [column[1] for column in cursor.fetchall()]
             if column_name not in columns:
                 raise ValueError(f"Column '{column_name}' does not exist in table '{table_name}'")
-            raise sqlite3.OperationalError(str(exc))
+            raise sqlite3.OperationalError("An unknown SQL error occurred")
 
     def update_data(
         self,

--- a/src/wxflow/sqlitedb.py
+++ b/src/wxflow/sqlitedb.py
@@ -1,7 +1,10 @@
 import sqlite3
 from typing import Any, List, Optional, Tuple
+from logging import getLogger
 
 __all__ = ["SQLiteDB"]
+
+logger = getLogger(__name__.split('.')[-1])
 
 
 class SQLiteDBError(Exception):
@@ -107,13 +110,14 @@ class SQLiteDB:
         try:
             query = f"ALTER TABLE {table_name} DROP COLUMN {column_name}"
             self.execute_query(query)
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as ee:
             query = f"PRAGMA table_info({table_name})"
             cursor = self.execute_query(query)
             columns = [column[1] for column in cursor.fetchall()]
             if column_name not in columns:
                 raise ValueError(f"Column '{column_name}' does not exist in table '{table_name}'")
-            raise sqlite3.OperationalError("An unknown SQL error occurred")
+            logger.exception(f"Failed to remove '{column_name}' from '{table_name}' due to an unknown error.")
+            raise ee
 
     def update_data(
         self,

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 from wxflow import FileHandler

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from wxflow import FileHandler
 
@@ -27,6 +28,12 @@ def test_mkdir(tmp_path):
         assert os.path.exists(dd)
 
 
+def test_bad_mkdir():
+    # Attempt to create a directory in an unwritable parent directory
+    with pytest.raises(OSError):
+        FileHandler({'mkdir': ["/dev/null/foo"]}).sync()
+
+
 def test_copy(tmp_path):
     """
     Test for copying files:
@@ -35,6 +42,7 @@ def test_copy(tmp_path):
     tmp_path - pytest fixture
     """
 
+    # Test 1 (nominal operation) - Creating a directory and copying files to it
     input_dir_path = tmp_path / 'my_input_dir'
 
     # Create the input directory
@@ -56,7 +64,7 @@ def test_copy(tmp_path):
     for src, dest in zip(src_files, dest_files):
         copy_list.append([src, dest])
 
-    # Create config object for FileHandler
+    # Create config dictionary for FileHandler
     config = {'copy': copy_list}
 
     # Copy input files to output files
@@ -66,17 +74,32 @@ def test_copy(tmp_path):
     for ff in dest_files:
         assert os.path.isfile(ff)
 
-    # Create a config object for copying optional non-existent files (c.txt does not exist)
+    # Test 2 - Attempt to copy files to a non-writable directory
+    # Create a list of bad targets (/dev/null is unwritable)
+    bad_dest_files = ["/dev/null/a.txt", "/dev/null/bb.txt"]
+
+    bad_copy_list = []
+    for src, dest in zip(src_files, bad_dest_files):
+        bad_copy_list.append([src, dest])
+
+    # Create a config dictionary for FileHandler
+    bad_config = {'copy': bad_copy_list}
+
+    # Attempt to copy
+    with pytest.raises(OSError):
+        FileHandler(bad_config).sync()
+
+    # Test 3 - Attempt to copy missing, optional files to a writable directory
+    # Create a config dictionary (c.txt does not exist)
     copy_list.append([input_dir_path / 'c.txt', output_dir_path / 'c.txt'])
     config = {'copy_opt': copy_list}
 
-    # Copy input files to output files
+    # Copy input files to output files (should not raise an error)
     FileHandler(config).sync()
 
-    # Create a config object for copying required non-existent files (c.txt does not exist)
+    # Test 4 - Attempt to copy missing, required files to a writable directory
+    # Create a config dictionary (c.txt does not exist)
     config = {'copy_req': copy_list}
-    try:
+    c_file = input_dir_path / 'c.txt'
+    with pytest.raises(FileNotFoundError, match=f"Source file '{c_file}' does not exist"):
         FileHandler(config).sync()
-    except FileNotFoundError as e:
-        c_file = input_dir_path / 'c.txt'
-        assert f"Source file '{c_file}' does not exist" in str(e)

--- a/tests/test_sqlitedb.py
+++ b/tests/test_sqlitedb.py
@@ -56,7 +56,7 @@ def test_remove_column(db):
     column_name = "address"
     db.remove_column("test_table", column_name)
 
-    # Verify that the column exists in the test table
+    # Verify that the column no longer exists in the test table
     assert not column_exists(db, "test_table", column_name)
 
 


### PR DESCRIPTION
**Description**

This fixes a few custom exceptions.  Attempting to raise an exception object results in an unintended/misleading error.  For instance,

```python
try:
    1/0
except Exception as exc:
    raise exc("You can't divide by zero")
```

Results in
```console
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
TypeError: 'ZeroDivisionError' object is not callable
```

Instead, the base exception should be casted as a string:
```python
try:
   1/0
except Exception as e:
   raise Exception(str(e) + "\nYou can't divide by zero")
```

Which returns
```console
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
ZeroDivisionError: division by zero

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
Exception: division by zero
You can't divide by zero
```

In many cases, this is purely redundant as the message will already appear above.  Thus, some exceptions were removed entirely or condensed.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] pynorms
- [x] pytests

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published