### PR TITLE
Add `link` to filehandler and its associated test

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Install wxflow and run tests with pytests
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Setup Python

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -118,21 +118,23 @@ class FileHandler:
         """Function to link all files specified in the list
 
         `filelist` should be in the form:
-        - [link name, target]
+        - [target, link name]
 
         Parameters
         ----------
         filelist : list
-                List of lists of [link name, target]
+                List of lists of [target, link name]
         """
         for sublist in filelist:
             if len(sublist) != 2:
                 raise IndexError(
-                    f"List must be of the form ['link name', 'target'], not {sublist}")
-            link_name = sublist[0]
-            target = sublist[1]
+                    f"List must be of the form ['target', 'link name'], not {sublist}")
+            target = sublist[0]
+            link_name = sublist[1]
+            if os.path.isdir(link_name):
+                link_name = os.path.join(link_name, os.path.basename(target))
             logger.info(f"Linking {link_name} to {target}")
             if not os.path.exists(target):
-                logger.warning(f"WARNING: Target file '{target}' does not exist!")
+                logger.warning(f"WARNING: Target file '{target}' does not exist, will result in dead link!")
             Path(link_name).symlink_to(target)
-            logger.info(f'Linked {link_name} to {target}')
+            logger.info(f'Linked {target} to {link_name}')

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -1,5 +1,6 @@
 import os
 from logging import getLogger
+from pathlib import Path
 
 from .fsutils import cp, mkdir
 
@@ -47,6 +48,7 @@ class FileHandler:
             'copy_req': self.copy_req,
             'copy_opt': self.copy_opt,
             'mkdir': self._make_dirs,
+            'link': self._link_files,
         }
         # loop through the configuration keys
         for action, files in self.config.items():
@@ -110,3 +112,27 @@ class FileHandler:
             except Exception as ee:
                 logger.exception(f"Error creating directory {dd}")
                 raise ee
+
+    @staticmethod
+    def _link_files(filelist):
+        """Function to link all files specified in the list
+
+        `filelist` should be in the form:
+        - [link name, target]
+
+        Parameters
+        ----------
+        filelist : list
+                List of lists of [link name, target]
+        """
+        for sublist in filelist:
+            if len(sublist) != 2:
+                raise IndexError(
+                    f"List must be of the form ['link name', 'target'], not {sublist}")
+            link_name = sublist[0]
+            target = sublist[1]
+            logger.info(f"Linking {link_name} to {target}")
+            if not os.path.exists(target):
+                logger.warning(f"WARNING: Target file '{target}' does not exist!")
+            Path(link_name).symlink_to(target)
+            logger.info(f'Linked {link_name} to {target}')

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -133,7 +133,6 @@ class FileHandler:
             link_name = sublist[1]
             if os.path.isdir(link_name):
                 link_name = os.path.join(link_name, os.path.basename(target))
-            logger.info(f"Linking {link_name} to {target}")
             if not os.path.exists(target):
                 logger.warning(f"WARNING: Target file '{target}' does not exist, will result in dead link!")
             Path(link_name).symlink_to(target)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -133,6 +133,26 @@ def create_dirs_and_files_for_test_link(tmp_path):
     FileHandler(config).sync()
 
 
+def test_link_file_invalid_config(tmp_path, create_dirs_and_files_for_test_link):
+    """
+    Test for linking files:
+    Parameters
+    ----------
+    tmp_path - pytest fixture
+    create_dirs_and_files_for_test_link - pytest fixture
+    """
+
+    input_dir_path = tmp_path / 'my_input_dir'
+    output_dir_path = tmp_path / 'my_output_dir1'
+
+    # Create config dictionary for FileHandler
+    bad_config = {'link': [[input_dir_path / 'a.txt'], [input_dir_path / 'b.txt', output_dir_path / 'b_link.txt']]}
+
+    # Attempt to link
+    with pytest.raises(IndexError):
+        FileHandler(bad_config).sync()
+
+
 def test_link_file_files(tmp_path, create_dirs_and_files_for_test_link):
     """
     Test for linking files:

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -106,15 +106,15 @@ def test_copy(tmp_path):
         FileHandler(config).sync()
 
 
-def test_link_files(tmp_path):
+@pytest.fixture
+def create_dirs_and_files_for_test_link(tmp_path):
     """
-    Test for linking files:
+    Create directories and files for testing linking files:
     Parameters
     ----------
     tmp_path - pytest fixture
     """
 
-    # Test 1 (nominal operation) - Creating a directory and linking files to it
     input_dir_path = tmp_path / 'my_input_dir'
 
     # Create the input directory
@@ -126,15 +126,33 @@ def test_link_files(tmp_path):
     for ff in src_files:
         ff.touch()
 
-    # Create output_dir_path and expected link names
-    output_dir_path = tmp_path / 'my_output_dir'
-    config = {'mkdir': [output_dir_path]}
+    # Create output_dir_path for this test
+    output_dir_path1 = tmp_path / 'my_output_dir1'
+    output_dir_path2 = tmp_path / 'my_output_dir2'
+    config = {'mkdir': [output_dir_path1, output_dir_path2]}
     FileHandler(config).sync()
+
+
+def test_link_file_files(tmp_path, create_dirs_and_files_for_test_link):
+    """
+    Test for linking files:
+    Parameters
+    ----------
+    tmp_path - pytest fixture
+    create_dirs_and_files_for_test_link - pytest fixture
+    """
+
+    input_dir_path = tmp_path / 'my_input_dir'
+    output_dir_path = tmp_path / 'my_output_dir1'
+
+    src_files = [input_dir_path / 'a.txt', input_dir_path / 'b.txt']
     link_files = [output_dir_path / 'a_link.txt', output_dir_path / 'b_link.txt']
 
     link_list = []
     for src, link in zip(src_files, link_files):
-        link_list.append([link, src])
+        link_list.append([src, link])
+        if os.path.exists(link):
+            os.unlink(link)
 
     # Create config dictionary for FileHandler
     config = {'link': link_list}
@@ -147,8 +165,54 @@ def test_link_files(tmp_path):
         assert os.path.islink(link)
         assert os.readlink(link) == str(src_files[link_files.index(link)])
 
-    # Test 2 - Attempt to link to a non-existent target (this will only throw a warning via logger)
-    bad_link_list = [[output_dir_path / 'bad_link.txt', input_dir_path / 'non_existent.txt']]
+
+def test_link_file_dir(tmp_path, create_dirs_and_files_for_test_link):
+    """
+    Test for linking files:
+    Parameters
+    ----------
+    tmp_path - pytest fixture
+    create_dirs_and_files_for_test_link - pytest fixture
+    """
+
+    input_dir_path = tmp_path / 'my_input_dir'
+    output_dir_path = tmp_path / 'my_output_dir2'
+
+    src_files = [input_dir_path / 'a.txt', input_dir_path / 'b.txt']
+    link_files = [str(output_dir_path) + '/', str(output_dir_path) + '/']
+
+    link_list = []
+    for src, link in zip(src_files, link_files):
+        link_list.append([src, link])
+        link_name = os.path.join(link, os.path.basename(src))
+        if os.path.exists(link_name):
+            os.unlink(link_name)
+
+    # Create config dictionary for FileHandler
+    config = {'link': link_list}
+
+    # Link input files to output links
+    FileHandler(config).sync()
+
+    # Check if links were indeed created
+    for src, link in zip(src_files, link_files):
+        link_name = os.path.join(link, os.path.basename(src))
+        assert os.path.islink(link_name)
+
+
+def test_link_file_bad(tmp_path, create_dirs_and_files_for_test_link):
+    """
+    Test for linking files:
+    Parameters
+    ----------
+    tmp_path - pytest fixture
+    create_dirs_and_files_for_test_link - pytest fixture
+    """
+
+    input_dir_path = tmp_path / 'my_input_dir'
+    output_dir_path = tmp_path / 'my_output_dir1'
+
+    bad_link_list = [[input_dir_path / 'non_existent.txt', output_dir_path / 'bad_link.txt']]
 
     # Create a config dictionary for FileHandler
     bad_config = {'link': bad_link_list}

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -156,5 +156,4 @@ def test_link_files(tmp_path):
 
     # Follow the bad link to the file and check this is a dead link to a file that does not exist
     pp = os.path.realpath(output_dir_path / 'bad_link.txt')
-    with pytest.raises(AssertionError):
-        assert os.path.isfile(pp)
+    assert not os.path.isfile(pp)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -104,3 +104,57 @@ def test_copy(tmp_path):
     c_file = input_dir_path / 'c.txt'
     with pytest.raises(FileNotFoundError, match=f"Source file '{c_file}' does not exist"):
         FileHandler(config).sync()
+
+
+def test_link_files(tmp_path):
+    """
+    Test for linking files:
+    Parameters
+    ----------
+    tmp_path - pytest fixture
+    """
+
+    # Test 1 (nominal operation) - Creating a directory and linking files to it
+    input_dir_path = tmp_path / 'my_input_dir'
+
+    # Create the input directory
+    config = {'mkdir': [input_dir_path]}
+    FileHandler(config).sync()
+
+    # Put empty files in input_dir_path
+    src_files = [input_dir_path / 'a.txt', input_dir_path / 'b.txt']
+    for ff in src_files:
+        ff.touch()
+
+    # Create output_dir_path and expected link names
+    output_dir_path = tmp_path / 'my_output_dir'
+    config = {'mkdir': [output_dir_path]}
+    FileHandler(config).sync()
+    link_files = [output_dir_path / 'a_link.txt', output_dir_path / 'b_link.txt']
+
+    link_list = []
+    for src, link in zip(src_files, link_files):
+        link_list.append([link, src])
+
+    # Create config dictionary for FileHandler
+    config = {'link': link_list}
+
+    # Link input files to output links
+    FileHandler(config).sync()
+
+    # Check if links were indeed created
+    for link in link_files:
+        assert os.path.islink(link)
+        assert os.readlink(link) == str(src_files[link_files.index(link)])
+
+    # Test 2 - Attempt to link to a non-existent target (this will only throw a warning via logger)
+    bad_link_list = [[output_dir_path / 'bad_link.txt', input_dir_path / 'non_existent.txt']]
+
+    # Create a config dictionary for FileHandler
+    bad_config = {'link': bad_link_list}
+    FileHandler(bad_config).sync()
+
+    # Follow the bad link to the file and check this is a dead link to a file that does not exist
+    pp = os.path.realpath(output_dir_path / 'bad_link.txt')
+    with pytest.raises(AssertionError):
+        assert os.path.isfile(pp)


### PR DESCRIPTION
**Description**
This PR:
- adds the ability to `link` files via `FileHandler`
- adds associated test for `link`.
- removes older python version tests as they are deprecated in the GH runner.

**Type of change**
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

**How Has This Been Tested?**

<!-- Please describe the tests that you ran to verify your changes and on the platforms these tests were conducted. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->
<!-- If adding a new feature, was an accompanying test added? -->

- [X] pynorms
- [X] pytests

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
