### PR TITLE
Remove symbolic link if it exists before linking

### DIFF
--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -135,5 +135,9 @@ class FileHandler:
                 link_name = os.path.join(link_name, os.path.basename(target))
             if not os.path.exists(target):
                 logger.warning(f"WARNING: Target file '{target}' does not exist, will result in dead link!")
-            Path(link_name).symlink_to(target)
-            logger.info(f'Linked {target} to {link_name}')
+            link_path = Path(link_name)
+            if link_path.is_symlink():
+                logger.warning(f"WARNING: Link to '{target}' exists at '{link_name}', removing!")
+                os.remove(link_name)
+            link_path.symlink_to(target)
+            logger.info(f"Linked '{target}' to '{link_name}'")

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -185,9 +185,13 @@ def test_link_file_files(tmp_path, create_dirs_and_files_for_test_link):
         assert os.path.islink(link)
         assert os.readlink(link) == str(src_files[link_files.index(link)])
 
-    # Creat Link input files to output links again to ensure removal of existing link
+    # Create link input files to output links again to ensure removal of existing link
     FileHandler(config).sync()
 
+    # Check if links were indeed created
+    for link in link_files:
+        assert os.path.islink(link)
+        assert os.readlink(link) == str(src_files[link_files.index(link)])
 
 
 def test_link_file_dir(tmp_path, create_dirs_and_files_for_test_link):

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -185,6 +185,10 @@ def test_link_file_files(tmp_path, create_dirs_and_files_for_test_link):
         assert os.path.islink(link)
         assert os.readlink(link) == str(src_files[link_files.index(link)])
 
+    # Creat Link input files to output links again to ensure removal of existing link
+    FileHandler(config).sync()
+
+
 
 def test_link_file_dir(tmp_path, create_dirs_and_files_for_test_link):
     """


### PR DESCRIPTION
**Description**
This PR:
- removes an existing symlink before trying to create over it.
- is akin to `ln -sf`

This was discovered during `stage_ic` in global-workflow when re-running left old directories and links in place.

**Type of change**
- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested?**

- [x] pynorms
- [x] pytests

The patch was tested in global-workflow where the error was detected.

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
