### PR TITLE
Raise an error if file lists are empty

### DIFF
--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -52,6 +52,8 @@ class FileHandler:
         }
         # loop through the configuration keys
         for action, files in self.config.items():
+            if files is None or len(files) == 0:
+                raise IndexError(f"No files/directories were included for {action} command")
             sync_factory[action](files)
 
     @staticmethod

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -53,7 +53,7 @@ class FileHandler:
         # loop through the configuration keys
         for action, files in self.config.items():
             if files is None or len(files) == 0:
-                raise IndexError(f"No files/directories were included for {action} command")
+                raise ValueError(f"No files/directories were included for {action} command")
             sync_factory[action](files)
 
     @staticmethod

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -37,9 +37,9 @@ def test_bad_mkdir():
 
 def test_empty_mkdir():
     # Attempt to create a directory in an unwritable parent directory
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         FileHandler({'mkdir': None}).sync()
-    with pytest.raises(IndexError):
+    with pytest.raises(ValueError):
         FileHandler({'mkdir': []}).sync()
 
 

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -35,6 +35,14 @@ def test_bad_mkdir():
         FileHandler({'mkdir': ["/dev/null/foo"]}).sync()
 
 
+def test_empty_mkdir():
+    # Attempt to create a directory in an unwritable parent directory
+    with pytest.raises(IndexError):
+        FileHandler({'mkdir': None}).sync()
+    with pytest.raises(IndexError):
+        FileHandler({'mkdir': []}).sync()
+
+
 def test_copy(tmp_path):
     """
     Test for copying files:


### PR DESCRIPTION
**Description**
This raises an error if the input file/directory lists to `sync` are empty.

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

Added new pytests
- [x] pynorms
- [x] pytests

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published