### PR TITLE
Replace error with a warning when empty lists are provided

### DIFF
--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -60,7 +60,8 @@ class FileHandler:
         # loop through the configuration keys
         for action, files in self.config.items():
             if files is None or len(files) == 0:
-                raise ValueError(f"No files/directories were included for {action} command")
+                logger.warning(f"WARNING: No files/directories were included for {action} command")
+                continue
             sync_factory[action](files)
 
     @staticmethod

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -35,12 +36,12 @@ def test_bad_mkdir():
         FileHandler({'mkdir': ["/dev/null/foo"]}).sync()
 
 
-def test_empty_mkdir():
-    # Attempt to create a directory in an unwritable parent directory
-    with pytest.raises(ValueError):
-        FileHandler({'mkdir': None}).sync()
-    with pytest.raises(ValueError):
-        FileHandler({'mkdir': []}).sync()
+def test_empty_lists(caplog):
+    caplog.set_level(logging.INFO)
+    FileHandler({'mkdir': None}).sync()
+    assert 'WARNING: No files/directories were included for mkdir command' in caplog.text
+    FileHandler({'copy': []}).sync()
+    assert 'WARNING: No files/directories were included for copy command' in caplog.text
 
 
 def test_copy(tmp_path):


### PR DESCRIPTION
**Description**
This PR:
- replaces the raising of `ValueError` with a `warning` when an empty list is provided for `mkdir`, `copy` and `link` actions.
- updates the corresponding test

**Type of change**
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
- [X] pynorms
- [X] pytests

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
