### PR TITLE
Add WorkflowKeyError and WorkflowTypeError exceptions

### DIFF
--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -3,7 +3,7 @@ import os
 from .attrdict import AttrDict
 from .configuration import (Configuration, cast_as_dtype,
                             cast_strdict_as_dtypedict)
-from .exceptions import WorkflowException, msg_except_handle
+from .exceptions import WorkflowException, WorkflowKeyError, WorkflowTypeError, msg_except_handle
 from .executable import CommandNotFoundError, Executable, ProcessError, which
 from .factory import Factory
 from .file_utils import FileHandler

--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -3,7 +3,7 @@ import os
 from .attrdict import AttrDict
 from .configuration import (Configuration, cast_as_dtype,
                             cast_strdict_as_dtypedict)
-from .exceptions import (WorkflowException, WorkflowKeyError, 
+from .exceptions import (WorkflowException, WorkflowKeyError,
                          WorkflowTypeError, msg_except_handle)
 from .executable import CommandNotFoundError, Executable, ProcessError, which
 from .factory import Factory

--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -3,7 +3,8 @@ import os
 from .attrdict import AttrDict
 from .configuration import (Configuration, cast_as_dtype,
                             cast_strdict_as_dtypedict)
-from .exceptions import WorkflowException, WorkflowKeyError, WorkflowTypeError, msg_except_handle
+from .exceptions import (WorkflowException, WorkflowKeyError, 
+                         WorkflowTypeError, msg_except_handle)
 from .executable import CommandNotFoundError, Executable, ProcessError, which
 from .factory import Factory
 from .file_utils import FileHandler

--- a/src/wxflow/exceptions.py
+++ b/src/wxflow/exceptions.py
@@ -8,7 +8,7 @@ from .logger import Logger, logit
 
 logger = Logger(level="error", colored_log=True)
 
-__all__ = ["WorkflowException", "msg_except_handle"]
+__all__ = ["WorkflowException", "WorkflowKeyError", "WorkflowTypeError", "msg_except_handle"]
 
 
 class WorkflowException(Exception):
@@ -43,6 +43,69 @@ class WorkflowException(Exception):
         logger.error(msg=msg)
         super().__init__()
 
+class WorkflowKeyError(KeyError):
+    """
+    Description
+    -----------
+
+    This is the workflow class for KeyError exceptions; it is a sub-class of
+    KeyError.
+
+    Parameters
+    ----------
+
+    msg: str
+
+        A Python string containing a message to accompany the
+        exception.
+
+    """
+
+    @logit(logger)
+    def __init__(self: Exception, msg: str):
+        """
+        Description
+        -----------
+
+        Creates a new WorkflowKeyError object.
+
+        """
+
+        # Define the base-class attributes.
+        logger.error(msg=msg)
+        super().__init__()
+
+class WorkflowTypeError(TypeError):
+    """
+    Description
+    -----------
+
+    This is the workflow class for TypeError exceptions; it is a sub-class of
+    TypeError.
+
+    Parameters
+    ----------
+
+    msg: str
+
+        A Python string containing a message to accompany the
+        exception.
+
+    """
+
+    @logit(logger)
+    def __init__(self: Exception, msg: str):
+        """
+        Description
+        -----------
+
+        Creates a new WorkflowTypeError object.
+
+        """
+
+        # Define the base-class attributes.
+        logger.error(msg=msg)
+        super().__init__()
 
 # ----
 

--- a/src/wxflow/exceptions.py
+++ b/src/wxflow/exceptions.py
@@ -29,7 +29,6 @@ class WorkflowException(Exception):
 
     """
 
-    @logit(logger)
     def __init__(self: Exception, msg: str):
         """
         Description
@@ -62,7 +61,6 @@ class WorkflowKeyError(KeyError):
 
     """
 
-    @logit(logger)
     def __init__(self: Exception, msg: str):
         """
         Description
@@ -95,7 +93,6 @@ class WorkflowTypeError(TypeError):
 
     """
 
-    @logit(logger)
     def __init__(self: Exception, msg: str):
         """
         Description

--- a/src/wxflow/exceptions.py
+++ b/src/wxflow/exceptions.py
@@ -41,7 +41,7 @@ class WorkflowException(Exception):
 
         # Define the base-class attributes.
         logger.error(msg=msg)
-        super().__init__()
+        super().__init__(msg)
 
 
 class WorkflowKeyError(KeyError):
@@ -74,7 +74,7 @@ class WorkflowKeyError(KeyError):
 
         # Define the base-class attributes.
         logger.error(msg=msg)
-        super().__init__()
+        super().__init__(msg)
 
 
 class WorkflowTypeError(TypeError):
@@ -107,7 +107,7 @@ class WorkflowTypeError(TypeError):
 
         # Define the base-class attributes.
         logger.error(msg=msg)
-        super().__init__()
+        super().__init__(msg)
 
 # ----
 

--- a/src/wxflow/exceptions.py
+++ b/src/wxflow/exceptions.py
@@ -43,6 +43,7 @@ class WorkflowException(Exception):
         logger.error(msg=msg)
         super().__init__()
 
+
 class WorkflowKeyError(KeyError):
     """
     Description
@@ -74,6 +75,7 @@ class WorkflowKeyError(KeyError):
         # Define the base-class attributes.
         logger.error(msg=msg)
         super().__init__()
+
 
 class WorkflowTypeError(TypeError):
     """

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,35 +1,86 @@
 import pytest
 
-from wxflow import WorkflowException
+from wxflow import WorkflowException, WorkflowKeyError, WorkflowTypeError
 
 # ----
 
 
-class TestError(WorkflowException):
+class TestWorkflowException(WorkflowException):
     """
     Description
     -----------
 
-    This is the base-class for exceptions encountered within the
-    wxflow/errors unit-tests module; it is a sub-class of Error.
+    This is the base-class for generic exceptions encountered within the
+    wxflow/errors unit-tests module; it is a sub-class of WorkflowException.
+
+    """
+
+class TestWorkflowKeyError(WorkflowKeyError):
+    """
+    Description
+    -----------
+
+    This is the base-class for KeyError exceptions encountered within the
+    wxflow/errors unit-tests module; it is a sub-class of WorkflowKeyError.
+
+    """
+
+class TestWorkflowTypeError(WorkflowTypeError):
+    """
+    Description
+    -----------
+
+    This is the base-class for TypeError exceptions encountered within the
+    wxflow/errors unit-tests module; it is a sub-class of WorkflowTypeError.
 
     """
 
 # ----
 
-
-def test_errors() -> None:
+def test_workflow_exception() -> None:
     """
     Description
     -----------
 
-    This function provides a unit test for the errors module.
+    This function provides a unit test for the WorkflowException class.
 
     """
 
     # Raise the base-class exception.
     with pytest.raises(Exception):
-        msg = "Testing exception raise."
-        raise TestError(msg=msg)
+        msg = "Testing WorkflowException raise."
+        raise TestWorkflowException(msg=msg)
+
+    assert True
+
+def test_workflow_key_error() -> None:
+    """
+    Description
+    -----------
+
+    TThis function provides a unit test for the WorkflowKeyError class.
+
+    """
+
+    # Raise the base-class exception.
+    with pytest.raises(Exception):
+        msg = "Testing WorkflowKeyError raise."
+        raise TestWorkflowKeyError(msg=msg)
+
+    assert True
+
+def test_workflow_type_error() -> None:
+    """
+    Description
+    -----------
+
+    TThis function provides a unit test for the WorkflowTypeError class.
+
+    """
+
+    # Raise the base-class exception.
+    with pytest.raises(Exception):
+        msg = "Testing WorkflowTypeError raise."
+        raise TestWorkflowTypeError(msg=msg)
 
     assert True

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -15,6 +15,7 @@ class TestWorkflowException(WorkflowException):
 
     """
 
+
 class TestWorkflowKeyError(WorkflowKeyError):
     """
     Description
@@ -24,6 +25,7 @@ class TestWorkflowKeyError(WorkflowKeyError):
     wxflow/errors unit-tests module; it is a sub-class of WorkflowKeyError.
 
     """
+
 
 class TestWorkflowTypeError(WorkflowTypeError):
     """
@@ -53,6 +55,7 @@ def test_workflow_exception() -> None:
 
     assert True
 
+
 def test_workflow_key_error() -> None:
     """
     Description
@@ -69,12 +72,13 @@ def test_workflow_key_error() -> None:
 
     assert True
 
+
 def test_workflow_type_error() -> None:
     """
     Description
     -----------
 
-    TThis function provides a unit test for the WorkflowTypeError class.
+    This function provides a unit test for the WorkflowTypeError class.
 
     """
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -39,6 +39,7 @@ class TestWorkflowTypeError(WorkflowTypeError):
 
 # ----
 
+
 def test_workflow_exception() -> None:
     """
     Description

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -50,7 +50,7 @@ def test_workflow_exception() -> None:
     """
 
     # Raise the base-class exception.
-    with pytest.raises(Exception):
+    with pytest.raises(TestWorkflowException):
         msg = "Testing WorkflowException raise."
         raise TestWorkflowException(msg=msg)
 
@@ -62,12 +62,12 @@ def test_workflow_key_error() -> None:
     Description
     -----------
 
-    TThis function provides a unit test for the WorkflowKeyError class.
+    This function provides a unit test for the WorkflowKeyError class.
 
     """
 
     # Raise the base-class exception.
-    with pytest.raises(Exception):
+    with pytest.raises(TestWorkflowKeyError):
         msg = "Testing WorkflowKeyError raise."
         raise TestWorkflowKeyError(msg=msg)
 
@@ -84,7 +84,7 @@ def test_workflow_type_error() -> None:
     """
 
     # Raise the base-class exception.
-    with pytest.raises(Exception):
+    with pytest.raises(TestWorkflowTypeError):
         msg = "Testing WorkflowTypeError raise."
         raise TestWorkflowTypeError(msg=msg)
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,44 +2,6 @@ import pytest
 
 from wxflow import WorkflowException, WorkflowKeyError, WorkflowTypeError
 
-# ----
-
-
-class TestWorkflowException(WorkflowException):
-    """
-    Description
-    -----------
-
-    This is the base-class for generic exceptions encountered within the
-    wxflow/errors unit-tests module; it is a sub-class of WorkflowException.
-
-    """
-
-
-class TestWorkflowKeyError(WorkflowKeyError):
-    """
-    Description
-    -----------
-
-    This is the base-class for KeyError exceptions encountered within the
-    wxflow/errors unit-tests module; it is a sub-class of WorkflowKeyError.
-
-    """
-
-
-class TestWorkflowTypeError(WorkflowTypeError):
-    """
-    Description
-    -----------
-
-    This is the base-class for TypeError exceptions encountered within the
-    wxflow/errors unit-tests module; it is a sub-class of WorkflowTypeError.
-
-    """
-
-# ----
-
-
 def test_workflow_exception() -> None:
     """
     Description
@@ -50,9 +12,9 @@ def test_workflow_exception() -> None:
     """
 
     # Raise the base-class exception.
-    with pytest.raises(TestWorkflowException):
+    with pytest.raises(WorkflowException):
         msg = "Testing WorkflowException raise."
-        raise TestWorkflowException(msg=msg)
+        raise WorkflowException(msg=msg)
 
     assert True
 
@@ -67,9 +29,9 @@ def test_workflow_key_error() -> None:
     """
 
     # Raise the base-class exception.
-    with pytest.raises(TestWorkflowKeyError):
+    with pytest.raises(WorkflowKeyError):
         msg = "Testing WorkflowKeyError raise."
-        raise TestWorkflowKeyError(msg=msg)
+        raise WorkflowKeyError(msg=msg)
 
     assert True
 
@@ -84,8 +46,8 @@ def test_workflow_type_error() -> None:
     """
 
     # Raise the base-class exception.
-    with pytest.raises(TestWorkflowTypeError):
+    with pytest.raises(WorkflowTypeError):
         msg = "Testing WorkflowTypeError raise."
-        raise TestWorkflowTypeError(msg=msg)
+        raise WorkflowTypeError(msg=msg)
 
     assert True

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,6 +2,7 @@ import pytest
 
 from wxflow import WorkflowException, WorkflowKeyError, WorkflowTypeError
 
+
 def test_workflow_exception() -> None:
     """
     Description


### PR DESCRIPTION
**Description**

This PR adds exception classes equivalent to `WorkflowException` for `TypeError` and `KeyError`. Like `WorkflowException`, these exception print to `logger.error`, but inherit from `TypeError` and `KeyError` classes.

Fixes https://github.com/NOAA-EMC/wxflow/issues/60

**Type of change**

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- [ ] pynorms
- [x] pytests

**Checklist**

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
