### PR TITLE
Add option for logger to suppress stdout

### DIFF
--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -12,7 +12,7 @@ from .fsutils import chdir, chgrp, cp, get_gid, mkdir, mkdir_p, rm_p, rmdir
 from .hsi import Hsi
 from .htar import Htar
 from .jinja import Jinja
-from .logger import Logger, logit, add_file_logger, add_stream_logger#, setup_logging
+from .logger import Logger, add_file_logger, add_stream_logger, logit
 from .scheduler.no_scheduler import NoScheduler
 from .scheduler.pbs import PBS
 from .scheduler.scheduler import Scheduler

--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -12,7 +12,7 @@ from .fsutils import chdir, chgrp, cp, get_gid, mkdir, mkdir_p, rm_p, rmdir
 from .hsi import Hsi
 from .htar import Htar
 from .jinja import Jinja
-from .logger import Logger, logit
+from .logger import Logger, logit, add_file_logger, add_stream_logger#, setup_logging
 from .scheduler.no_scheduler import NoScheduler
 from .scheduler.pbs import PBS
 from .scheduler.scheduler import Scheduler

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -51,7 +51,7 @@ class Logger:
     DEFAULT_FORMAT = '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
 
     def __init__(self, name: str = None,
-                 level: str = os.environ.get("LOGGING_LEVEL"),
+                 level: str = os.environ.get("LOGGING_LEVEL", "INFO"),
                  _format: str = DEFAULT_FORMAT,
                  colored_log: bool = False,
                  stdout: bool = True,
@@ -82,7 +82,7 @@ class Logger:
         """
 
         self.name = name if name else 'root'
-        self.level = level.upper() if level else Logger.DEFAULT_LEVEL
+        self.level = level.upper()
         self.format = _format
         self.colored_log = colored_log
         self.stdout = stdout

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -7,9 +7,11 @@ import os
 import sys
 from functools import wraps
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 
-__all__ = ['Logger', 'logit']
+__all__ = ['Logger', 'logit', 'setup_logging', 'add_stream_logger', 'add_file_logger']
+
+DEFAULT_FORMAT = '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
 
 
 class ColoredFormatter(logging.Formatter):
@@ -46,12 +48,8 @@ class Logger:
     """
     Improved logging
     """
-    LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
-    DEFAULT_LEVEL = 'INFO'
-    DEFAULT_FORMAT = '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
-
     def __init__(self, name: str = None,
-                 level: str = os.environ.get("LOGGING_LEVEL"),
+                 level: str = os.environ.get("LOGGING_LEVEL", "INFO"),
                  _format: str = DEFAULT_FORMAT,
                  colored_log: bool = False,
                  stdout: bool = True,
@@ -82,55 +80,21 @@ class Logger:
         """
 
         self.name = name
-        self.level = level.upper() if level else Logger.DEFAULT_LEVEL
-        self.format = _format
+        self.level = level
+        self._format = _format
         self.colored_log = colored_log
+        self.stdout = stdout
+        self.logfile_path = logfile_path
 
-        if self.level not in Logger.LOG_LEVELS:
-            raise LookupError(f"{self.level} is unknown logging level\n" +
-                              f"Currently supported log levels are:\n" +
-                              f"{' | '.join(Logger.LOG_LEVELS)}")
+        setup_logging(level=self.level,
+                      _format=self._format,
+                      colored_log=self.colored_log,
+                      stdout=self.stdout,
+                      logfile_path=self.logfile_path)
 
-        # Check if the root logger or named logger is already initialized
-        logger_keys = logging.Logger.manager.loggerDict.keys()
-        my_keys = ['root'] if self.name is None else ['root', self.name]
-        if any(item in logger_keys for item in my_keys):
-            # If the logger is already initialized, we will not reinitialize it
-            # This is to avoid duplicate logs
-            return
+        self._logger = logging.getLogger(name) if name else logging.getLogger()
 
-        # Initialize the root logger
-        self._logger = logging.getLogger()
-        if self.name:
-            self._logger.name = self.name
-
-        self._logger.setLevel(self.level)
-
-        # Disable propagation to avoid duplicate logs
-        self._logger.propagate = False
-
-        # Remove all existing handlers
-        for handler in self._logger.handlers:
-            self._logger.removeHandler(handler)
-
-        # Create a list of handlers
-        _handlers = []
-
-        # Add console handler for logger
-        if stdout:
-            _handler = Logger.add_stream_handler(
-                level=self.level, _format=self.format, colored_log=self.colored_log)
-            _handlers.append(_handler)
-
-        # Add file handler for logger
-        if logfile_path is not None:
-            _handler = Logger.add_file_handler(
-                logfile_path, level=self.level, _format=self.format)
-            _handlers.append(_handler)
-
-        # Add all handlers to the logger
-        for _handler in _handlers:
-            self._logger.addHandler(_handler)
+        return
 
     def __getattr__(self, attribute):
         """
@@ -157,100 +121,79 @@ class Logger:
         """
         return self._logger
 
-    @classmethod
-    def add_handlers(cls, logger: logging.Logger, handlers: List[logging.Handler]):
-        """
-        Add a list of handlers to a logger
 
-        Parameters
-        ----------
-        logger : logging.Logger
-                 Logger object to add a new handler to
-        handlers: list
-                 A list of handlers to be added to the logger object
+def add_stream_logger(logger: logging.Logger,
+                      level: str = 'INFO',
+                      _format: str = DEFAULT_FORMAT,
+                      colored_log: bool = False):
+    """
+    Log to stdout
+    This method will allow setting a custom stream handler on the logger
 
-        Returns
-        -------
-        logger : Logger object
-        """
-        for handler in handlers:
-            logger.addHandler(handler)
+    Parameters
+    ----------
+    logger : logging.Logger
+             Logger object to add a new handler to
+    level : str
+            logging level
+            default : 'INFO'
+    _format : str
+              logging format
+              default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
+    colored_log : bool
+                  enable colored output for stdout
+                  default : False
 
-        return logger
+    Returns
+    -------
+    None
+    """
 
-    @classmethod
-    def add_stream_handler(cls, level: str = DEFAULT_LEVEL,
-                           _format: str = DEFAULT_FORMAT,
-                           colored_log: bool = False):
-        """
-        Create stream handler
-        This classmethod will allow setting a custom stream handler on children
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(level)
+    _format = ColoredFormatter(
+        _format) if colored_log else logging.Formatter(_format)
+    handler.setFormatter(_format)
+    logger.addHandler(handler)
 
-        Parameters
-        ----------
-        level : str
-                logging level
-                default : 'INFO'
-        _format : str
-                  logging format
-                  default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
-        colored_log : bool
-                      enable colored output for stdout
-                      default : False
 
-        Returns
-        -------
-        handler : logging.Handler
-                  stream handler of a logging object
-        """
+def add_file_logger(logger: logging.Logger,
+                    logfile_path: Union[str, Path],
+                    level: str = os.environ.get("LOGGING_LEVEL", "INFO"),
+                    _format: str = DEFAULT_FORMAT):
+    """
+    Log to a file
+    This method will allow setting custom file handler on the logger
 
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setLevel(level)
-        _format = ColoredFormatter(
-            _format) if colored_log else logging.Formatter(_format)
-        handler.setFormatter(_format)
+    Parameters
+    ----------
+    logger : logging.Logger
+             Logger object to add a new handler to
+    logfile_path: str or Path
+                  Path for writing out logfiles from logging
+                  default : None
+    level : str
+            logging level
+            default : 'INFO'
+    _format : str
+              logging format
+              default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
 
-        return handler
+    Returns
+    -------
+    None
+    """
 
-    @classmethod
-    def add_file_handler(cls, logfile_path: Union[str, Path],
-                         level: str = DEFAULT_LEVEL,
-                         _format: str = DEFAULT_FORMAT):
-        """
-        Create file handler.
-        This classmethod will allow setting custom file handler on children
-        Create stream handler
-        This classmethod will allow setting a custom stream handler on children
+    logfile_path = Path(logfile_path)
 
-        Parameters
-        ----------
-        logfile_path: str or Path
-                      Path for writing out logfiles from logging
-                      default : False
-        level : str
-                logging level
-                default : 'INFO'
-        _format : str
-                  logging format
-                  default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
+    # Create the directory containing the logfile_path
+    if not logfile_path.parent.is_dir():
+        logfile_path.mkdir(parents=True, exist_ok=True)
 
-        Returns
-        -------
-        handler : logging.Handler
-                  file handler of a logging object
-        """
-
-        logfile_path = Path(logfile_path)
-
-        # Create the directory containing the logfile_path
-        if not logfile_path.parent.is_dir():
-            logfile_path.mkdir(parents=True, exist_ok=True)
-
-        handler = logging.FileHandler(str(logfile_path))
-        handler.setLevel(level)
-        handler.setFormatter(logging.Formatter(_format))
-
-        return handler
+    handler = logging.FileHandler(str(logfile_path))
+    handler.setLevel(level)
+    handler.setFormatter(logging.Formatter(_format))
+    logger.addHandler(handler)
 
 
 def logit(logger, name=None, message=None):
@@ -298,3 +241,67 @@ def logit(logger, name=None, message=None):
         return wrapper
 
     return decorate
+
+
+def setup_logging(level: str = os.environ.get("LOGGING_LEVEL", "INFO"),
+                  _format: str = DEFAULT_FORMAT,
+                  colored_log: bool = False,
+                  stdout: bool = True,
+                  logfile_path: Union[str, Path] = None):
+    """
+    Setup logging with the given parameters.
+
+    Parameters
+    ----------
+    level        : str
+                   Logging level
+                   default : 'INFO'
+    _format      : str
+                   Logging format
+                   default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
+    colored_log  : bool
+                   Use colored logging for stdout
+                   default: False
+    stdout       : bool
+                   Enable logging to stdout
+                   default : True
+    logfile_path : str or Path
+                   Path for logging to a file
+                   default : None
+
+    Returns
+    -------
+    logger : Logger object
+             Configured logger instance.
+    """
+
+    LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+
+    print(f"Inputs: {level=}, {_format=}, {colored_log=}, {stdout=}, {logfile_path=}")
+
+    _level = level.upper()
+    _ilevel = getattr(logging, _level, logging.INFO)
+    print(f"Will set up logging with {level=}, {_level=}, {_ilevel=}")
+
+    if _level not in LOG_LEVELS:
+        raise LookupError(f"{level} is unknown logging level\n" +
+                              f"Currently supported log levels are:\n" +
+                              f"{' | '.join(LOG_LEVELS)}")
+
+    logger = logging.getLogger()
+
+    # Remove all existing handlers
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+
+    logging.basicConfig(level=_ilevel, format=_format)
+    #logger = logging.getLogger()
+    print("Logger initialized with level:", logger.level)
+
+    # Add console handler for logger
+    if stdout:
+        add_stream_logger(logger, level=_level, _format=_format, colored_log=colored_log)
+
+    # Add file handler for logger
+    if logfile_path is not None:
+        add_file_logger(logger, logfile_path, level=_level, _format=format)

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -75,7 +75,7 @@ class Logger:
                        default: False
         stdout       : bool
                        Stream to stdout
-                       default: False
+                       default: True
         logfile_path : str or Path
                        Path for logging to a file
                        default : None
@@ -98,9 +98,6 @@ class Logger:
 
         # Initialize logger if no name is present
         self._logger = logging.getLogger(name) if name else self._root_logger
-
-        # If a name is provided, set the parent logger to the root logger
-        self._parent_logger = self._logger.parent if name else self._root_logger
 
         self._logger.setLevel(self.level)
 
@@ -187,7 +184,6 @@ def add_file_logger(logger: logging.Logger,
     """
     Stream output to a logfile
     This method will allow setting custom file handler on children
-    Create stream handler
 
     Parameters
     ----------

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -54,6 +54,7 @@ class Logger:
                  level: str = os.environ.get("LOGGING_LEVEL"),
                  _format: str = DEFAULT_FORMAT,
                  colored_log: bool = False,
+                 stdout: bool = True,
                  logfile_path: Union[str, Path] = None):
         """
         Initialize Logger
@@ -72,6 +73,9 @@ class Logger:
         colored_log  : bool
                        Use colored logging for stdout
                        default: False
+        stdout       : bool
+                       Enable logging to stdout
+                       default : True
         logfile_path : str or Path
                        Path for logging to a file
                        default : None
@@ -87,27 +91,46 @@ class Logger:
                               f"Currently supported log levels are:\n" +
                               f"{' | '.join(Logger.LOG_LEVELS)}")
 
-        # Initialize the root logger if no name is present
-        self._logger = logging.getLogger(name) if name else logging.getLogger()
+        # Check if the root logger or named logger is already initialized
+        logger_keys = logging.Logger.manager.loggerDict.keys()
+        my_keys = ['root'] if self.name is None else ['root', self.name]
+        if any(item in logger_keys for item in my_keys):
+            # If the logger is already initialized, we will not reinitialize it
+            # This is to avoid duplicate logs
+            return
+
+        # Initialize the root logger
+        self._logger = logging.getLogger()
+        if self.name:
+            self._logger.name = self.name
 
         self._logger.setLevel(self.level)
 
+        # Disable propagation to avoid duplicate logs
+        self._logger.propagate = False
+
+        # Remove all existing handlers
+        for handler in self._logger.handlers:
+            self._logger.removeHandler(handler)
+
+        # Create a list of handlers
         _handlers = []
+
         # Add console handler for logger
-        _handler = Logger.add_stream_handler(
-            level=self.level,
-            _format=self.format,
-            colored_log=self.colored_log,
-        )
-        _handlers.append(_handler)
-        self._logger.addHandler(_handler)
+        if stdout:
+            _handler = Logger.add_stream_handler(
+                level=self.level, _format=self.format, colored_log=self.colored_log)
+            _handlers.append(_handler)
 
         # Add file handler for logger
         if logfile_path is not None:
             _handler = Logger.add_file_handler(
                 logfile_path, level=self.level, _format=self.format)
-            self._logger.addHandler(_handler)
             _handlers.append(_handler)
+
+        # Add all handlers to the logger
+        for _handler in _handlers:
+            self._logger.addHandler(_handler)
 
     def __getattr__(self, attribute):
         """

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -9,9 +9,7 @@ from functools import wraps
 from pathlib import Path
 from typing import Union
 
-__all__ = ['Logger', 'logit', 'setup_logging', 'add_stream_logger', 'add_file_logger']
-
-DEFAULT_FORMAT = '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
+__all__ = ['Logger', 'add_stream_logger', 'add_file_logger', 'logit']
 
 
 class ColoredFormatter(logging.Formatter):
@@ -48,8 +46,12 @@ class Logger:
     """
     Improved logging
     """
+    LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+    DEFAULT_LEVEL = 'INFO'
+    DEFAULT_FORMAT = '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
+
     def __init__(self, name: str = None,
-                 level: str = os.environ.get("LOGGING_LEVEL", "INFO"),
+                 level: str = os.environ.get("LOGGING_LEVEL"),
                  _format: str = DEFAULT_FORMAT,
                  colored_log: bool = False,
                  stdout: bool = True,
@@ -60,7 +62,7 @@ class Logger:
         Parameters
         ----------
         name         : str
-                       Name of the Logger object
+                       Name of the Logger object (None implies root logger)
                        default : None
         level        : str
                        Desired Logging level
@@ -72,29 +74,50 @@ class Logger:
                        Use colored logging for stdout
                        default: False
         stdout       : bool
-                       Enable logging to stdout
-                       default : True
+                       Stream to stdout
+                       default: False
         logfile_path : str or Path
                        Path for logging to a file
                        default : None
         """
 
-        self.name = name
-        self.level = level
-        self._format = _format
+        self.name = name if name else 'root'
+        self.level = level.upper() if level else Logger.DEFAULT_LEVEL
+        self.format = _format
         self.colored_log = colored_log
         self.stdout = stdout
         self.logfile_path = logfile_path
 
-        setup_logging(level=self.level,
-                      _format=self._format,
-                      colored_log=self.colored_log,
-                      stdout=self.stdout,
-                      logfile_path=self.logfile_path)
+        if self.level not in Logger.LOG_LEVELS:
+            raise LookupError(f"{level} (case insensitive) is unknown logging level\n" +
+                              f"Currently supported log levels are:\n" +
+                              f"{' | '.join(Logger.LOG_LEVELS)}")
 
-        self._logger = logging.getLogger(name) if name else logging.getLogger()
+        # Initialize the root logger
+        self._root_logger = logging.getLogger()
 
-        return
+        # Initialize logger if no name is present
+        self._logger = logging.getLogger(name) if name else self._root_logger
+
+        # If a name is provided, set the parent logger to the root logger
+        self._parent_logger = self._logger.parent if name else self._root_logger
+
+        self._logger.setLevel(self.level)
+
+        # Disable propagation to avoid duplicate logs in parent loggers
+        self._logger.propagate = False
+
+        # Remove all existing handlers attached to this logger
+        for _handler in self._logger.handlers:
+            self._logger.removeHandler(_handler)
+
+        # Stream to stdout
+        if self.stdout:
+            add_stream_logger(self._logger, level=self.level, _format=self.format, colored_log=self.colored_log)
+
+        # Stream to file
+        if self.logfile_path is not None:
+            add_file_logger(self._logger, self.logfile_path, level=self.level, _format=self.format)
 
     def __getattr__(self, attribute):
         """
@@ -122,27 +145,27 @@ class Logger:
         return self._logger
 
 
-def add_stream_logger(logger: logging.Logger,
-                      level: str = 'INFO',
-                      _format: str = DEFAULT_FORMAT,
+def add_stream_logger(logger: Logger,
+                      level: str = Logger.DEFAULT_LEVEL,
+                      _format: str = Logger.DEFAULT_FORMAT,
                       colored_log: bool = False):
     """
-    Log to stdout
-    This method will allow setting a custom stream handler on the logger
+    Stream logs to stdout
+    This method will allow setting a custom stream handler on children
 
     Parameters
     ----------
     logger : logging.Logger
-             Logger object to add a new handler to
+             Logger object to which the stream handler will be added
     level : str
             logging level
             default : 'INFO'
     _format : str
-              logging format
-              default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
+                logging format
+                default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
     colored_log : bool
-                  enable colored output for stdout
-                  default : False
+                    enable colored output for stdout
+                    default : False
 
     Returns
     -------
@@ -150,7 +173,7 @@ def add_stream_logger(logger: logging.Logger,
     """
 
     handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(level)
+    handler.setLevel(level.upper())
     _format = ColoredFormatter(
         _format) if colored_log else logging.Formatter(_format)
     handler.setFormatter(_format)
@@ -159,25 +182,26 @@ def add_stream_logger(logger: logging.Logger,
 
 def add_file_logger(logger: logging.Logger,
                     logfile_path: Union[str, Path],
-                    level: str = os.environ.get("LOGGING_LEVEL", "INFO"),
-                    _format: str = DEFAULT_FORMAT):
+                    level: str = Logger.DEFAULT_LEVEL,
+                    _format: str = Logger.DEFAULT_FORMAT):
     """
-    Log to a file
-    This method will allow setting custom file handler on the logger
+    Stream output to a logfile
+    This method will allow setting custom file handler on children
+    Create stream handler
 
     Parameters
     ----------
     logger : logging.Logger
-             Logger object to add a new handler to
+             Logger object to which the file handler will be added
     logfile_path: str or Path
-                  Path for writing out logfiles from logging
-                  default : None
+                    Path for writing out logfiles from logging
+                    default : False
     level : str
             logging level
             default : 'INFO'
     _format : str
-              logging format
-              default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
+                logging format
+                default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
 
     Returns
     -------
@@ -191,7 +215,7 @@ def add_file_logger(logger: logging.Logger,
         logfile_path.mkdir(parents=True, exist_ok=True)
 
     handler = logging.FileHandler(str(logfile_path))
-    handler.setLevel(level)
+    handler.setLevel(level.upper())
     handler.setFormatter(logging.Formatter(_format))
     logger.addHandler(handler)
 
@@ -241,67 +265,3 @@ def logit(logger, name=None, message=None):
         return wrapper
 
     return decorate
-
-
-def setup_logging(level: str = os.environ.get("LOGGING_LEVEL", "INFO"),
-                  _format: str = DEFAULT_FORMAT,
-                  colored_log: bool = False,
-                  stdout: bool = True,
-                  logfile_path: Union[str, Path] = None):
-    """
-    Setup logging with the given parameters.
-
-    Parameters
-    ----------
-    level        : str
-                   Logging level
-                   default : 'INFO'
-    _format      : str
-                   Logging format
-                   default : '%(asctime)s - %(levelname)-8s - %(name)-12s: %(message)s'
-    colored_log  : bool
-                   Use colored logging for stdout
-                   default: False
-    stdout       : bool
-                   Enable logging to stdout
-                   default : True
-    logfile_path : str or Path
-                   Path for logging to a file
-                   default : None
-
-    Returns
-    -------
-    logger : Logger object
-             Configured logger instance.
-    """
-
-    LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
-
-    print(f"Inputs: {level=}, {_format=}, {colored_log=}, {stdout=}, {logfile_path=}")
-
-    _level = level.upper()
-    _ilevel = getattr(logging, _level, logging.INFO)
-    print(f"Will set up logging with {level=}, {_level=}, {_ilevel=}")
-
-    if _level not in LOG_LEVELS:
-        raise LookupError(f"{level} is unknown logging level\n" +
-                              f"Currently supported log levels are:\n" +
-                              f"{' | '.join(LOG_LEVELS)}")
-
-    logger = logging.getLogger()
-
-    # Remove all existing handlers
-    for handler in logger.handlers:
-        logger.removeHandler(handler)
-
-    logging.basicConfig(level=_ilevel, format=_format)
-    #logger = logging.getLogger()
-    print("Logger initialized with level:", logger.level)
-
-    # Add console handler for logger
-    if stdout:
-        add_stream_logger(logger, level=_level, _format=_format, colored_log=colored_log)
-
-    # Add file handler for logger
-    if logfile_path is not None:
-        add_file_logger(logger, logfile_path, level=_level, _format=format)

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -7,7 +7,7 @@ import os
 import sys
 from functools import wraps
 from pathlib import Path
-from typing import Union
+from typing import Any, Union
 
 __all__ = ['Logger', 'add_stream_logger', 'add_file_logger', 'logit']
 
@@ -119,7 +119,7 @@ class Logger:
         if self.logfile_path is not None:
             add_file_logger(self._logger, self.logfile_path, level=self.level, _format=self.format)
 
-    def __getattr__(self, attribute):
+    def __getattr__(self, attribute: str) -> Any:
         """
         Allows calling logging module methods directly
 
@@ -145,7 +145,7 @@ class Logger:
         return self._logger
 
 
-def add_stream_logger(logger: Logger,
+def add_stream_logger(logger: logging.Logger,
                       level: str = Logger.DEFAULT_LEVEL,
                       _format: str = Logger.DEFAULT_FORMAT,
                       colored_log: bool = False):
@@ -220,14 +220,14 @@ def add_file_logger(logger: logging.Logger,
     logger.addHandler(handler)
 
 
-def logit(logger, name=None, message=None):
+def logit(logger: logging.Logger, name: str = None, message: str = None):
     """
     Logger decorator to add logging to a function.
     Simply add:
     @logit(logger) before any function
     Parameters
     ----------
-    logger  : Logger
+    logger  : logging.Logger
               Logger object
     name    : str
               Name of the module to be logged

--- a/tests/test_fsutils.py
+++ b/tests/test_fsutils.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 
@@ -146,5 +147,8 @@ def test_get_gid():
     with pytest.raises(KeyError):
         get_gid("some-non-existent-group")
 
-    # Now get the root group ID (should be 0)
-    assert get_gid("root") == 0
+    # Now get the group ID for root [0] (admin [80] on macOS)
+    if sys.platform == 'darwin':
+        assert get_gid("admin") == 80
+    else:
+        assert get_gid("root") == 0

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,4 +1,17 @@
+import logging
+
 from wxflow import Logger, logit
+
+"""
+Testing of the wxflow logger module
+
+Testing of logging is tricky, because the logger is a singleton.
+This means that the logging.getLogger should be called only once.
+This is to avoid duplicate logs.
+
+Here, this is achieved, by calling the test_logger_init first.
+Without this, the wxflow.Logger will not be initialized, and the tests will fail.
+"""
 
 level = 'debug'
 number_of_log_msgs = 5
@@ -9,13 +22,42 @@ reference = {'debug': "Logging test has started",
              'critical': "He's dead, She's dead.  They are all dead!"}
 
 
-def test_logger(tmp_path):
+def test_logger_init():  # This should be the first test to run (always)
+    """Test logger initialization"""
+
+    # Initialize logger
+    log = Logger('test_logger_init', level=level, colored_log=True)
+    log.info("Logger initialized for test_logger_init")
+
+    # Check if logger is initialized correctly
+    assert log._logger.name == 'test_logger_init'
+
+
+def test_logger_stdout():
+    """Test log to stdout"""
+
+    log = logging.getLogger('test_logger_stdout')
+
+    try:
+        log.debug(reference['debug'])
+        log.info(reference['info'])
+        log.warning(reference['warning'])
+        log.error(reference['error'])
+        log.critical(reference['critical'])
+    except Exception as e:
+        raise AssertionError(f'logging failed as {e}')
+
+
+def test_logger_file(tmp_path):
     """Test log file"""
 
     logfile = tmp_path / "logger.log"
 
+    log = logging.getLogger('test_logger_file')
+    fh = Logger.add_file_handler(logfile, level=log.level)
+    Logger.add_handlers(log, [fh])
+
     try:
-        log = Logger('test_logger', level=level, logfile_path=logfile, colored_log=True)
         log.debug(reference['debug'])
         log.info(reference['info'])
         log.warning(reference['warning'])
@@ -36,15 +78,15 @@ def test_logger(tmp_path):
     assert log_msgs_in_logfile == number_of_log_msgs
 
     # Ensure messages themselves are same
-    for count, line in enumerate(log_msgs):
+    for _, line in enumerate(log_msgs):
         lev = line.split('-')[3].strip().lower()
         message = line.split(':')[-1].strip()
         assert reference[lev] == message
 
 
-def test_logit(tmp_path):
+def test_logit():
 
-    logger = Logger('test_logit', level=level, colored_log=True)
+    logger = logging.getLogger('test_logit')
 
     @logit(logger)
     def add(x, y):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,6 @@
 import logging
 
-from wxflow import Logger, logit
+from wxflow import Logger, logit#, setup_logging, add_file_logger
 
 """
 Testing of the wxflow logger module
@@ -26,83 +26,88 @@ def test_logger_init():  # This should be the first test to run (always)
     """Test logger initialization"""
 
     # Initialize logger
-    log = Logger('test_logger_init', level=level, colored_log=True)
-    log.info("Logger initialized for test_logger_init")
+    #_ = Logger(level=level, colored_log=True)
+    #setup_logging(level=level, colored_log=True)
+    log = logging.getLogger()
+    print("Logger initialized with level:", log.level)
+
+    #log = logging.getLogger('test_logger_init')
+    #log.info("Logger initialized for test_logger_init")
 
     # Check if logger is initialized correctly
-    assert log._logger.name == 'test_logger_init'
+    #assert log.name == 'test_logger_init'
 
 
-def test_logger_stdout():
-    """Test log to stdout"""
-
-    log = logging.getLogger('test_logger_stdout')
-
-    try:
-        log.debug(reference['debug'])
-        log.info(reference['info'])
-        log.warning(reference['warning'])
-        log.error(reference['error'])
-        log.critical(reference['critical'])
-    except Exception as e:
-        raise AssertionError(f'logging failed as {e}')
-
-
-def test_logger_file(tmp_path):
-    """Test log file"""
-
-    logfile = tmp_path / "logger.log"
-
-    log = logging.getLogger('test_logger_file')
-    fh = Logger.add_file_handler(logfile, level=log.level)
-    Logger.add_handlers(log, [fh])
-
-    try:
-        log.debug(reference['debug'])
-        log.info(reference['info'])
-        log.warning(reference['warning'])
-        log.error(reference['error'])
-        log.critical(reference['critical'])
-    except Exception as e:
-        raise AssertionError(f'logging failed as {e}')
-
-    # Make sure log to file created messages
-    try:
-        with open(logfile, 'r') as fh:
-            log_msgs = fh.readlines()
-    except Exception as e:
-        raise AssertionError(f'failed reading log file as {e}')
-
-    # Ensure number of messages are same
-    log_msgs_in_logfile = len(log_msgs)
-    assert log_msgs_in_logfile == number_of_log_msgs
-
-    # Ensure messages themselves are same
-    for _, line in enumerate(log_msgs):
-        lev = line.split('-')[3].strip().lower()
-        message = line.split(':')[-1].strip()
-        assert reference[lev] == message
+#def test_logger_stdout():
+#    """Test log to stdout"""
+#
+#    log = logging.getLogger('test_logger_stdout', level=logging.DEBUG)
+#
+#    try:
+#        log.debug(reference['debug'])
+#        log.info(reference['info'])
+#        log.warning(reference['warning'])
+#        log.error(reference['error'])
+#        log.critical(reference['critical'])
+#    except Exception as e:
+#        raise AssertionError(f'logging failed as {e}')
 
 
-def test_logit():
-
-    logger = logging.getLogger('test_logit')
-
-    @logit(logger)
-    def add(x, y):
-        return x + y
-
-    @logit(logger)
-    def usedict(n, j=0, k=1):
-        return n + j + k
-
-    @logit(logger, 'example')
-    def spam():
-        print('Spam!')
-
-    add(2, 3)
-    usedict(2, 3)
-    usedict(2, k=3)
-    spam()
-
-    assert True
+#def test_logger_file(tmp_path):
+#    """Test log file"""
+#
+#    logfile = tmp_path / "logger.log"
+#
+#    log = logging.getLogger('test_logger_file')
+#    add_file_logger(log, logfile, level=log.level)
+#
+#    try:
+#        log.debug(reference['debug'])
+#        log.info(reference['info'])
+#        log.warning(reference['warning'])
+#        log.error(reference['error'])
+#        log.critical(reference['critical'])
+#    except Exception as e:
+#        raise AssertionError(f'logging failed as {e}')
+#
+#    # Make sure log to file created messages
+#    try:
+#        with open(logfile, 'r') as fh:
+#            log_msgs = fh.readlines()
+#    except Exception as e:
+#        raise AssertionError(f'failed reading log file as {e}')
+#
+#    # Ensure number of messages are same
+#    log_msgs_in_logfile = len(log_msgs)
+#    assert log_msgs_in_logfile == number_of_log_msgs
+#
+#    # Ensure messages themselves are same
+#    for _, line in enumerate(log_msgs):
+#        lev = line.split('-')[3].strip().lower()
+#        message = line.split(':')[-1].strip()
+#        assert reference[lev] == message
+#
+#
+#def test_logit():
+#
+#    logger = logging.getLogger('test_logit')
+#
+#    @logit(logger)
+#    def add(x, y):
+#        return x + y
+#
+#    @logit(logger)
+#    def usedict(n, j=0, k=1):
+#        return n + j + k
+#
+#    @logit(logger, 'example')
+#    def spam():
+#        print('Spam!')
+#
+#    add(2, 3)
+#    usedict(2, 3)
+#    usedict(2, k=3)
+#    spam()
+#
+#    assert True
+#

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -14,12 +14,12 @@ Without this, the wxflow.Logger will not be initialized, and the tests will fail
 """
 
 level = 'debug'
-number_of_log_msgs = 5
 reference = {'debug': "Logging test has started",
              'info': "Logging to 'logger.log' in the script dir",
              'warning': "This is my last warning, take heed",
              'error': "This is an error",
              'critical': "He's dead, She's dead.  They are all dead!"}
+number_of_log_msgs = len(reference.keys())
 
 
 def test_logger_init():  # This should be the first test to run (always)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,17 +1,8 @@
 import logging
 
-from wxflow import Logger, logit#, setup_logging, add_file_logger
+import pytest
 
-"""
-Testing of the wxflow logger module
-
-Testing of logging is tricky, because the logger is a singleton.
-This means that the logging.getLogger should be called only once.
-This is to avoid duplicate logs.
-
-Here, this is achieved, by calling the test_logger_init first.
-Without this, the wxflow.Logger will not be initialized, and the tests will fail.
-"""
+from wxflow import Logger, add_file_logger, add_stream_logger, logit
 
 level = 'debug'
 reference = {'debug': "Logging test has started",
@@ -22,92 +13,92 @@ reference = {'debug': "Logging test has started",
 number_of_log_msgs = len(reference.keys())
 
 
-def test_logger_init():  # This should be the first test to run (always)
+@pytest.fixture(scope='module')
+def logger_init():
     """Test logger initialization"""
 
-    # Initialize logger
-    #_ = Logger(level=level, colored_log=True)
-    #setup_logging(level=level, colored_log=True)
-    log = logging.getLogger()
-    print("Logger initialized with level:", log.level)
+    try:
+        _ = Logger(level='info', stdout=False, colored_log=False)
+    except Exception as ee:
+        raise AssertionError(f'Logger initialization failed as {ee}')
 
-    #log = logging.getLogger('test_logger_init')
-    #log.info("Logger initialized for test_logger_init")
-
-    # Check if logger is initialized correctly
-    #assert log.name == 'test_logger_init'
+    assert True, "Logger initialized successfully"
 
 
-#def test_logger_stdout():
-#    """Test log to stdout"""
-#
-#    log = logging.getLogger('test_logger_stdout', level=logging.DEBUG)
-#
-#    try:
-#        log.debug(reference['debug'])
-#        log.info(reference['info'])
-#        log.warning(reference['warning'])
-#        log.error(reference['error'])
-#        log.critical(reference['critical'])
-#    except Exception as e:
-#        raise AssertionError(f'logging failed as {e}')
+def test_logger_stdout(logger_init):
+    """Test log to stdout"""
+
+    try:
+        log = logging.getLogger('test_logger_stdout')
+        add_stream_logger(log, level='warning', colored_log=True)
+        log.debug(reference['debug'])
+        log.info(reference['info'])
+        log.warning(reference['warning'])
+        log.error(reference['error'])
+        log.critical(reference['critical'])
+    except Exception as e:
+        raise AssertionError(f'Logging to stdout failed as {e}')
+
+    assert True, "Logger to stdout tested successfully"
 
 
-#def test_logger_file(tmp_path):
-#    """Test log file"""
-#
-#    logfile = tmp_path / "logger.log"
-#
-#    log = logging.getLogger('test_logger_file')
-#    add_file_logger(log, logfile, level=log.level)
-#
-#    try:
-#        log.debug(reference['debug'])
-#        log.info(reference['info'])
-#        log.warning(reference['warning'])
-#        log.error(reference['error'])
-#        log.critical(reference['critical'])
-#    except Exception as e:
-#        raise AssertionError(f'logging failed as {e}')
-#
-#    # Make sure log to file created messages
-#    try:
-#        with open(logfile, 'r') as fh:
-#            log_msgs = fh.readlines()
-#    except Exception as e:
-#        raise AssertionError(f'failed reading log file as {e}')
-#
-#    # Ensure number of messages are same
-#    log_msgs_in_logfile = len(log_msgs)
-#    assert log_msgs_in_logfile == number_of_log_msgs
-#
-#    # Ensure messages themselves are same
-#    for _, line in enumerate(log_msgs):
-#        lev = line.split('-')[3].strip().lower()
-#        message = line.split(':')[-1].strip()
-#        assert reference[lev] == message
-#
-#
-#def test_logit():
-#
-#    logger = logging.getLogger('test_logit')
-#
-#    @logit(logger)
-#    def add(x, y):
-#        return x + y
-#
-#    @logit(logger)
-#    def usedict(n, j=0, k=1):
-#        return n + j + k
-#
-#    @logit(logger, 'example')
-#    def spam():
-#        print('Spam!')
-#
-#    add(2, 3)
-#    usedict(2, 3)
-#    usedict(2, k=3)
-#    spam()
-#
-#    assert True
-#
+def test_logger_file(tmp_path, logger_init):
+    """Test log to file"""
+
+    logfile = tmp_path / "logger.log"
+
+    try:
+        log = logging.getLogger('test_logger_file')
+        add_file_logger(log, level='debug', logfile_path=logfile)
+        # Since the lowest logger level in root is 'info', we need to reduce the level to 'debug' to all loggers
+        log.setLevel(logging.DEBUG)
+        log.debug(reference['debug'])
+        log.info(reference['info'])
+        log.warning(reference['warning'])
+        log.error(reference['error'])
+        log.critical(reference['critical'])
+    except Exception as e:
+        raise AssertionError(f'logging failed as {e}')
+
+    # Make sure log to file created messages
+    try:
+        with open(logfile, 'r') as fh:
+            log_msgs = fh.readlines()
+    except Exception as e:
+        raise AssertionError(f'failed reading log file as {e}')
+
+    # Ensure number of messages are same
+    log_msgs_in_logfile = len(log_msgs)
+    assert log_msgs_in_logfile == number_of_log_msgs, \
+        f"Expected {number_of_log_msgs} messages, but found {log_msgs_in_logfile}"
+
+    # Ensure messages themselves are same
+    for _, line in enumerate(log_msgs):
+        lev = line.split('-')[3].strip().lower()
+        message = line.split(':')[-1].strip()
+        assert reference[lev] == message, \
+            f"Expected message '{reference[lev]}' but found '{message}' in log file"
+
+
+def test_logger_logit(logger_init):
+
+    logger = Logger('test_logit', level=level, colored_log=True)
+
+    @logit(logger)
+    def add(x, y):
+        return x + y
+
+    @logit(logger)
+    def usedict(n, j=0, k=1):
+        return n + j + k
+
+    @logit(logger, 'example')
+    def spam():
+        print('Spam!')
+
+    add(2, 3)
+    usedict(2, 3)
+    usedict(2, k=3)
+    spam()
+
+    assert True

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -73,7 +73,7 @@ def test_logger_file(tmp_path, logger_init):
         f"Expected {number_of_log_msgs} messages, but found {log_msgs_in_logfile}"
 
     # Ensure messages themselves are same
-    for _, line in enumerate(log_msgs):
+    for line in log_msgs:
         lev = line.split('-')[3].strip().lower()
         message = line.split(':')[-1].strip()
         assert reference[lev] == message, \


### PR DESCRIPTION
**Description**
This PR:
- adds an option `stdout=True|False` when initializing the logger.  This is useful when a logs are being directed to a logfile, and do not want to be part of stdout.  @TerrenceMcGuinness-NOAA requested this for capturing output in a logfile for rocotostat collection.
-  also fixes the problem of duplicate logs.  It was observed sometime that duplicate logs were being printed.  To avoid this, the code is updated to check if a logger with the name `root` or chosen name exists.  If it does, the Logger class will return without calling a new `getLogger`.  This can be further improved, but will need coordination.  @DavidNew-NOAA first observed this.
- also fixes a failing test on macOS.  There is no `root` group on macOS; instead use `admin`

**Type of change**
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update.  Documentation will be automatically updated via the API update.

**How Has This Been Tested?**

- [X] pynorms
- [X] pytests

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
