### PR TITLE
Feature/parse j2tmpl

### DIFF
--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -11,7 +11,7 @@ from .file_utils import FileHandler
 from .fsutils import chdir, chgrp, cp, get_gid, mkdir, mkdir_p, rm_p, rmdir
 from .hsi import Hsi
 from .htar import Htar
-from .jinja import Jinja
+from .jinja import Jinja, parse_j2tmpl
 from .logger import Logger, add_file_logger, add_stream_logger, logit
 from .scheduler.no_scheduler import NoScheduler
 from .scheduler.pbs import PBS

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -260,3 +260,27 @@ class Jinja:
         None
         """
         sys.stdout.write(self.render)
+
+
+def parse_j2tmpl(template_path_or_string: str, data: Dict, output_file=None):
+        """
+        Description
+        -----------
+        Render a jinja2 template and optionally write the output to file
+        Parameters
+        -----------
+        template_path_or_string : str
+            Path to the template file or a templated string
+        data : dict
+            Data to be substituted into the template
+        output_file: str
+        Path to the output file
+        Returns
+        -------
+        None
+        """
+        jobj = Jinja(template_path_or_string, data)
+        if output_file is None:
+            return jobj.render
+        else:
+            jobj.save(output_file)

--- a/src/wxflow/jinja.py
+++ b/src/wxflow/jinja.py
@@ -10,7 +10,7 @@ from markupsafe import Markup
 from .timetools import (add_to_datetime, strftime, to_fv3time, to_isotime,
                         to_julian, to_timedelta, to_YMD, to_YMDH)
 
-__all__ = ['Jinja']
+__all__ = ['Jinja', 'parse_j2tmpl']
 
 
 @jinja2.pass_eval_context
@@ -263,24 +263,24 @@ class Jinja:
 
 
 def parse_j2tmpl(template_path_or_string: str, data: Dict, output_file=None):
-        """
-        Description
-        -----------
-        Render a jinja2 template and optionally write the output to file
-        Parameters
-        -----------
-        template_path_or_string : str
-            Path to the template file or a templated string
-        data : dict
-            Data to be substituted into the template
-        output_file: str
-        Path to the output file
-        Returns
-        -------
-        None
-        """
-        jobj = Jinja(template_path_or_string, data)
-        if output_file is None:
-            return jobj.render
-        else:
-            jobj.save(output_file)
+    """
+    Description
+    -----------
+    Render a jinja2 template and optionally write the output to file
+    Parameters
+    -----------
+    template_path_or_string : str
+        Path to the template file or a templated string
+    data : dict
+        Data to be substituted into the template
+    output_file: str
+    Path to the output file
+    Returns
+    -------
+    None
+    """
+    jobj = Jinja(template_path_or_string, data)
+    if output_file is None:
+        return jobj.render
+    else:
+        jobj.save(output_file)

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import jinja2
 import pytest
 
-from wxflow import Jinja, to_isotime
+from wxflow import Jinja, parse_j2tmpl, to_isotime
 
 current_date = datetime.now()
 j2tmpl = """Hello {{ name }}! {{ greeting }} It is: {{ current_date | to_isotime }}"""
@@ -118,3 +118,27 @@ def test_jinja_filters(tmp_path, create_template):
     file_path = tmp_path / 'template.j2'
     assert env.filters["path_exists"](file_path) is True
     assert env.filters["path_exists"]("/non/existent/path") is False
+
+
+def test_parse_j2tmpl_return(tmp_path, create_template):
+
+    file_path = tmp_path / 'include_template.j2'
+
+    data = {"my_name": "Jill", "name": "Joe", "greeting": "How are you?", "current_date": current_date}
+
+    filled = parse_j2tmpl(str(file_path), data)
+    assert filled == f"I am Jill. Hello Joe! How are you? It is: {to_isotime(current_date)}"
+
+
+def test_parse_j2tmpl_output(tmp_path, create_template):
+
+    file_path = tmp_path / 'include_template.j2'
+    output_file_path = tmp_path / 'rendered.txt'
+
+    data = {"my_name": "Jill", "name": "Joe", "greeting": "How are you?", "current_date": current_date}
+
+    parse_j2tmpl(str(file_path), data, output_file=str(output_file_path))
+
+    with open(output_file_path, 'r') as fh:
+        lines = fh.read()
+    assert lines == f"I am Jill. Hello Joe! How are you? It is: {to_isotime(current_date)}"


### PR DESCRIPTION
**Description**
This PR:
- adds a helper utility to parse jinja2 templates in a single pass.

This PR was motivated by additions in https://github.com/NOAA-EMC/global-workflow/pull/3713/files#r2607785371

**Type of change**
- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
- [X] pynorms
- [X] pytests

**Checklist**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] Any dependent changes have been merged and published
