### PR TITLE
Add paths to logit decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+tmp/
 
 # Translations
 *.mo

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -237,6 +237,7 @@ def logit(logger: logging.Logger, name: str = None, message: str = None):
 
         log_name = name if name else func.__module__
         log_msg = message if message else log_name + "." + func.__name__
+        file_path = func.__code__.co_filename  # Get the file path of the function
 
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -246,6 +247,7 @@ def logit(logger: logging.Logger, name: str = None, message: str = None):
 
             call_msg = 'BEGIN: ' + log_msg
             logger.info(call_msg)
+            logger.info("Called function file path: " + file_path)
             logger.debug(f"( {', '.join(passed_args + passed_kwargs)} )")
 
             # Call the function

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -236,8 +236,8 @@ def logit(logger: logging.Logger, name: str = None, message: str = None):
     def decorate(func):
 
         log_name = name if name else func.__module__
-        log_msg = message if message else log_name + "." + func.__name__
         file_path = func.__code__.co_filename  # Get the file path of the function
+        log_msg = message if message else log_name + "." + func.__name__ + ": " + file_path
 
         @wraps(func)
         def wrapper(*args, **kwargs):
@@ -247,7 +247,6 @@ def logit(logger: logging.Logger, name: str = None, message: str = None):
 
             call_msg = 'BEGIN: ' + log_msg
             logger.info(call_msg)
-            logger.info("Called function file path: " + file_path)
             logger.debug(f"( {', '.join(passed_args + passed_kwargs)} )")
 
             # Call the function

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -107,5 +107,5 @@ def test_logger_logit(tmp_path, logger_init):
         log_contents = fh.read()
 
     # Assert that the message contains the test file name full path
-    assert 'Begin: tests.test_logger.add: '+ str(__file__) in log_contents, \
+    assert 'BEGIN: tests.test_logger.add: '+ str(__file__) in log_contents, \
         "Expected test file name to be logged"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -106,7 +106,6 @@ def test_logger_logit(tmp_path, logger_init):
     with open(logfile, 'r') as fh:
         log_contents = fh.read()
 
-    assert 'Called function file path:' in log_contents, \
-        "Expected 'Called function file path:' to be in log messages"
-    assert 'test_logger.py' in log_contents, \
+    # Assert that the message contains the test file name full path
+    assert 'Begin: tests.test_logger.add: '+ str(__file__) in log_contents, \
         "Expected test file name to be logged"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -107,5 +107,5 @@ def test_logger_logit(tmp_path, logger_init):
         log_contents = fh.read()
 
     # Assert that the message contains the test file name full path
-    assert 'BEGIN: tests.test_logger.add: '+ str(__file__) in log_contents, \
+    assert 'BEGIN: tests.test_logger.add: ' + str(__file__) in log_contents, \
         "Expected test file name to be logged"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -80,7 +80,31 @@ def test_logger_file(tmp_path, logger_init):
             f"Expected message '{reference[lev]}' but found '{message}' in log file"
 
 
-def test_logger_logit(tmp_path, logger_init):
+def test_logger_logit_stdout(logger_init):
+
+    logger = Logger('test_logit', level=level, colored_log=True)
+
+    @logit(logger)
+    def add(x, y):
+        return x + y
+
+    @logit(logger)
+    def usedict(n, j=0, k=1):
+        return n + j + k
+
+    @logit(logger, 'example')
+    def spam():
+        print('Spam!')
+
+    add(2, 3)
+    usedict(2, 3)
+    usedict(2, k=3)
+    spam()
+
+    assert True
+
+
+def test_logger_logit_logfile(tmp_path, logger_init):
 
     logfile = tmp_path / "logit.log"
     logger = Logger('test_logit', level=level, colored_log=True, logfile_path=logfile)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -80,9 +80,10 @@ def test_logger_file(tmp_path, logger_init):
             f"Expected message '{reference[lev]}' but found '{message}' in log file"
 
 
-def test_logger_logit(logger_init):
+def test_logger_logit(tmp_path, logger_init):
 
-    logger = Logger('test_logit', level=level, colored_log=True)
+    logfile = tmp_path / "logit.log"
+    logger = Logger('test_logit', level=level, colored_log=True, logfile_path=logfile)
 
     @logit(logger)
     def add(x, y):
@@ -101,4 +102,11 @@ def test_logger_logit(logger_init):
     usedict(2, k=3)
     spam()
 
-    assert True
+    # Verify that file paths are logged
+    with open(logfile, 'r') as fh:
+        log_contents = fh.read()
+
+    assert 'Called function file path:' in log_contents, \
+        "Expected 'Called function file path:' to be in log messages"
+    assert 'test_logger.py' in log_contents, \
+        "Expected test file name to be logged"


### PR DESCRIPTION
**Description**
This adds a new feature to log the full path to a called function's file name.

Refs NOAA-EMC/global-workflow#4493
**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

I added a new pytest that ensures that logging includes the full filename.

- [x] pynorms
- [x] pytests

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes