### PR TITLE
Do not log `self` and do not write ANSI color codes when writing/piping output to a file

### DIFF
--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -145,7 +145,8 @@ class Logger:
 def add_stream_logger(logger: logging.Logger,
                       level: str = Logger.DEFAULT_LEVEL,
                       _format: str = Logger.DEFAULT_FORMAT,
-                      colored_log: bool = False):
+                      colored_log: bool = False,
+                      stream=None):
     """
     Stream logs to stdout
     This method will allow setting a custom stream handler on children
@@ -163,16 +164,29 @@ def add_stream_logger(logger: logging.Logger,
     colored_log : bool
                     enable colored output for stdout
                     default : False
+    stream : file-like object
+                Stream to write logs to. Colored formatting is only applied when
+                the stream is a TTY (terminal). When the stream is redirected to a
+                file, formatting characters are automatically suppressed.
+                default : sys.stdout
 
     Returns
     -------
     None
     """
 
-    handler = logging.StreamHandler(sys.stdout)
+    if stream is None:
+        stream = sys.stdout
+
+    handler = logging.StreamHandler(stream)
     handler.setLevel(level.upper())
-    _format = ColoredFormatter(
-        _format) if colored_log else logging.Formatter(_format)
+    # Only use colored formatting when the stream is a TTY to avoid writing
+    # ANSI escape codes into log files or piped output.
+    try:
+        is_tty = colored_log and hasattr(stream, 'isatty') and stream.isatty()
+    except Exception:
+        is_tty = False
+    _format = ColoredFormatter(_format) if is_tty else logging.Formatter(_format)
     handler.setFormatter(_format)
     logger.addHandler(handler)
 

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -8,6 +8,7 @@ import sys
 from functools import wraps
 from pathlib import Path
 from typing import Any, Union
+import inspect
 
 __all__ = ['Logger', 'add_stream_logger', 'add_file_logger', 'logit']
 
@@ -260,13 +261,10 @@ def logit(logger: logging.Logger, name: str = None, message: str = None):
             passed_args = []
             # Determine if the function is an instance method.
             if len(args) > 0:
-                if hasattr(args[0], '__class__'):
-                    class_name = args[0].__class__.__name__
-                    for aa in args:
-                        if isinstance(aa, args[0].__class__):
-                            passed_args.append(f"{class_name} object")
-                        else:
-                            passed_args.append(repr(aa))
+                if inspect.signature(func).parameters.get('self') is not None:
+                    class_name=args[0].__class__.__name__
+                    passed_args.append(f"{class_name} object")
+                    passed_args.extend([repr(aa) for aa in args[1:]])
                 else:
                     passed_args = [repr(aa) for aa in args]
 

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -242,7 +242,8 @@ def logit(logger: logging.Logger, name: str = None, message: str = None):
         @wraps(func)
         def wrapper(*args, **kwargs):
 
-            passed_args = [repr(aa) for aa in args]
+            # Get all of the arguments passed to the function and log them, skipping the self argument if it exists.
+            passed_args = [repr(aa) for aa in args if aa != 'self']
             passed_kwargs = [f"{kk}={repr(vv)}" for kk, vv in list(kwargs.items())]
 
             call_msg = 'BEGIN: ' + log_msg

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -262,7 +262,7 @@ def logit(logger: logging.Logger, name: str = None, message: str = None):
             # Determine if the function is an instance method.
             if len(args) > 0:
                 if inspect.signature(func).parameters.get('self') is not None:
-                    class_name=args[0].__class__.__name__
+                    class_name = args[0].__class__.__name__
                     passed_args.append(f"{class_name} object")
                     passed_args.extend([repr(aa) for aa in args[1:]])
                 else:

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -242,8 +242,17 @@ def logit(logger: logging.Logger, name: str = None, message: str = None):
         @wraps(func)
         def wrapper(*args, **kwargs):
 
-            # Get all of the arguments passed to the function and log them, skipping the self argument if it exists.
-            passed_args = [repr(aa) for aa in args if aa != 'self']
+            # Get all of the arguments passed to the function and log them, skipping 'self'.
+            passed_args = []
+            # Determine if the function is an instance method.
+            if len(args) > 0 and hasattr(args[0], '__class__'):
+                class_name = args[0].__class__.__name__
+                for aa in args:
+                    if isinstance(aa, args[0].__class__):
+                        passed_args.append(f"{class_name} object")
+                    else:
+                        passed_args.append(repr(aa))
+
             passed_kwargs = [f"{kk}={repr(vv)}" for kk, vv in list(kwargs.items())]
 
             call_msg = 'BEGIN: ' + log_msg

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -245,13 +245,16 @@ def logit(logger: logging.Logger, name: str = None, message: str = None):
             # Get all of the arguments passed to the function and log them, skipping 'self'.
             passed_args = []
             # Determine if the function is an instance method.
-            if len(args) > 0 and hasattr(args[0], '__class__'):
-                class_name = args[0].__class__.__name__
-                for aa in args:
-                    if isinstance(aa, args[0].__class__):
-                        passed_args.append(f"{class_name} object")
-                    else:
-                        passed_args.append(repr(aa))
+            if len(args) > 0:
+                if hasattr(args[0], '__class__'):
+                    class_name = args[0].__class__.__name__
+                    for aa in args:
+                        if isinstance(aa, args[0].__class__):
+                            passed_args.append(f"{class_name} object")
+                        else:
+                            passed_args.append(repr(aa))
+                else:
+                    passed_args = [repr(aa) for aa in args]
 
             passed_kwargs = [f"{kk}={repr(vv)}" for kk, vv in list(kwargs.items())]
 

--- a/src/wxflow/logger.py
+++ b/src/wxflow/logger.py
@@ -2,13 +2,13 @@
 Logger
 """
 
+import inspect
 import logging
 import os
 import sys
 from functools import wraps
 from pathlib import Path
 from typing import Any, Union
-import inspect
 
 __all__ = ['Logger', 'add_stream_logger', 'add_file_logger', 'logit']
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,8 +1,13 @@
+import io
 import logging
+import re
 
 import pytest
 
 from wxflow import Logger, add_file_logger, add_stream_logger, logit
+
+# Regex that matches ANSI escape sequences (e.g. \x1b[38;21m)
+ANSI_ESCAPE_RE = re.compile(r'\x1b\[[0-9;]*m')
 
 level = 'debug'
 reference = {'debug': "Logging test has started",
@@ -133,3 +138,66 @@ def test_logger_logit_logfile(tmp_path, logger_init):
     # Assert that the message contains the test file name full path
     assert 'BEGIN: tests.test_logger.add: ' + str(__file__) in log_contents, \
         "Expected test file name to be logged"
+
+    # Assert that no ANSI escape codes are present in the log file even though
+    # colored_log=True was requested (file is not a TTY)
+    assert not ANSI_ESCAPE_RE.search(log_contents), \
+        "Log file must not contain ANSI escape/formatting characters"
+
+
+def test_stream_logger_no_ansi_on_non_tty(logger_init):
+    """Test that colored_log=True does not emit ANSI codes when stream is not a TTY"""
+
+    stream = io.StringIO()
+    log = logging.getLogger('test_no_ansi_non_tty')
+    add_stream_logger(log, level='debug', colored_log=True, stream=stream)
+    log.setLevel(logging.DEBUG)
+    log.debug(reference['debug'])
+    log.info(reference['info'])
+    log.warning(reference['warning'])
+    log.error(reference['error'])
+    log.critical(reference['critical'])
+
+    content = stream.getvalue()
+    assert not ANSI_ESCAPE_RE.search(content), \
+        "Stream output must not contain ANSI escape/formatting characters when stream is not a TTY"
+
+
+def test_stream_logger_ansi_on_tty(logger_init):
+    """Test that colored_log=True emits ANSI codes when stream is a TTY"""
+
+    class _FakeTTY(io.StringIO):
+        def isatty(self):
+            return True
+
+    stream = _FakeTTY()
+    log = logging.getLogger('test_ansi_tty')
+    add_stream_logger(log, level='debug', colored_log=True, stream=stream)
+    log.setLevel(logging.DEBUG)
+    log.info(reference['info'])
+
+    content = stream.getvalue()
+    assert ANSI_ESCAPE_RE.search(content), \
+        "Stream output must contain ANSI escape/formatting characters when stream is a TTY and colored_log=True"
+
+
+def test_file_logger_no_ansi(tmp_path, logger_init):
+    """Test that log files written via add_file_logger never contain ANSI codes"""
+
+    logfile = tmp_path / "no_ansi.log"
+    log = logging.getLogger('test_file_no_ansi')
+    add_file_logger(log, level='debug', logfile_path=logfile)
+    log.setLevel(logging.DEBUG)
+
+    for msg in reference.values():
+        log.debug(msg)
+        log.info(msg)
+        log.warning(msg)
+        log.error(msg)
+        log.critical(msg)
+
+    with open(logfile, 'r') as fh:
+        log_contents = fh.read()
+
+    assert not ANSI_ESCAPE_RE.search(log_contents), \
+        "Log file written by add_file_logger must not contain ANSI escape/formatting characters"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -134,6 +134,7 @@ def test_logger_logit_logfile(tmp_path, logger_init):
     assert 'BEGIN: tests.test_logger.add: ' + str(__file__) in log_contents, \
         "Expected test file name to be logged"
 
+
 def test_logger_logit_instance_method(tmp_path, logger_init):
 
     logfile = tmp_path / "logit_instance.log"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -169,6 +169,48 @@ def test_logger_logit_instance_method(tmp_path, logger_init):
     assert 'MyClass object' in log_contents, "Expected MyClass method name to be logged. Actual log contents: " + log_contents
 
 
+def test_logger_logit_noninstance_method(tmp_path, logger_init):
+
+    logfile = tmp_path / "logit_noninstance.log"
+    logger = Logger('test_logit_noninstance', level=level, colored_log=True, logfile_path=logfile)
+
+    class DummyClass:
+        def __str__(self):
+            return "DummyClass instance"
+
+    class MyClass:
+        @staticmethod
+        @logit(logger)
+        def non_instance_method(x):
+            return x * 3
+
+        @staticmethod
+        @logit(logger)
+        def non_instance_method_object_arg(obj):
+            return str(obj)
+
+    result = MyClass.non_instance_method(5)
+    assert result == 15, "Expected non-instance method to return 15"
+
+    obj = DummyClass()
+
+    result = MyClass.non_instance_method_object_arg(obj)
+    assert result == "DummyClass instance", "Expected non-instance method to return string representation of DummyClass instance"
+
+    # Check the logfile for correct logging of non-instance method and object argument
+    with open(logfile, 'r') as fh:
+        log_contents = fh.read()
+    assert 'BEGIN: tests.test_logger.non_instance_method: ' + str(__file__) in log_contents, \
+        "Expected non-instance method name to be logged. Actual log contents: " + log_contents
+
+    assert 'BEGIN: tests.test_logger.non_instance_method_object_arg: ' + str(__file__) in log_contents, \
+        "Expected non-instance method name to be logged. Actual log contents: " + log_contents
+
+    # Make sure that the string representation is not simply'DummyClass object' but includes the instance's memory address (default __str__ for objects)
+    assert 'DummyClass object at' in log_contents, \
+        "Expected string representation of DummyClass instance to be logged. Actual log contents: " + log_contents
+
+
 def test_stream_logger_no_ansi_on_non_tty(logger_init):
     """Test that colored_log=True does not emit ANSI codes when stream is not a TTY"""
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import re
+import sys
 
 import pytest
 
@@ -201,3 +202,52 @@ def test_file_logger_no_ansi(tmp_path, logger_init):
 
     assert not ANSI_ESCAPE_RE.search(log_contents), \
         "Log file written by add_file_logger must not contain ANSI escape/formatting characters"
+
+
+def test_stream_logger_no_ansi_when_stdout_redirected(logger_init, monkeypatch):
+    """Test that no ANSI codes appear when sys.stdout is redirected (bash: script.py > log.txt)
+
+    Simulates what happens when an entire bash script is redirected to a file.
+    add_stream_logger is called without an explicit stream so it uses sys.stdout,
+    which is no longer a TTY when redirected by the shell.
+    """
+
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, 'stdout', buf)
+
+    log = logging.getLogger('test_redirected_stdout')
+    # Call without explicit stream — mirrors real-world usage; sys.stdout is used internally
+    add_stream_logger(log, level='debug', colored_log=True)
+    log.setLevel(logging.DEBUG)
+    log.debug(reference['debug'])
+    log.info(reference['info'])
+    log.warning(reference['warning'])
+    log.error(reference['error'])
+    log.critical(reference['critical'])
+
+    content = buf.getvalue()
+    assert not ANSI_ESCAPE_RE.search(content), \
+        "Output must not contain ANSI escape/formatting characters when sys.stdout is redirected"
+
+
+def test_logger_class_no_ansi_when_stdout_redirected(logger_init, monkeypatch):
+    """Test that Logger(colored_log=True) emits no ANSI codes when sys.stdout is redirected
+
+    Simulates: ./run_script.sh > logfile.log 2>&1
+    The Logger class must automatically detect the redirection and suppress color codes.
+    """
+
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, 'stdout', buf)
+
+    logger = Logger('test_logger_redirect', level='debug', colored_log=True)
+    logger.setLevel(logging.DEBUG)
+    logger.debug(reference['debug'])
+    logger.info(reference['info'])
+    logger.warning(reference['warning'])
+    logger.error(reference['error'])
+    logger.critical(reference['critical'])
+
+    content = buf.getvalue()
+    assert not ANSI_ESCAPE_RE.search(content), \
+        "Logger output must not contain ANSI escape/formatting characters when sys.stdout is redirected"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -166,7 +166,8 @@ def test_logger_logit_instance_method(tmp_path, logger_init):
 
     # Assert that the message contains the test file name full path
     assert 'BEGIN: tests.test_logger.instance_method: ' + str(__file__) in log_contents
-    assert 'MyClass object' in log_contents, "Expected MyClass method name to be logged. Actual log contents: " + log_contents
+    assert not re.search(r'<[^>]*MyClass object at 0x[0-9A-Fa-f]+>', log_contents), \
+        "Log output must not contain the default MyClass self repr with memory address. Actual log contents: " + log_contents
 
 
 def test_logger_logit_noninstance_method(tmp_path, logger_init):
@@ -206,9 +207,9 @@ def test_logger_logit_noninstance_method(tmp_path, logger_init):
     assert 'BEGIN: tests.test_logger.non_instance_method_object_arg: ' + str(__file__) in log_contents, \
         "Expected non-instance method name to be logged. Actual log contents: " + log_contents
 
-    # Make sure that the string representation is not simply'DummyClass object' but includes the instance's memory address (default __str__ for objects)
+    # Make sure that the logged object representation is the default repr, which includes the instance's memory address
     assert 'DummyClass object at' in log_contents, \
-        "Expected string representation of DummyClass instance to be logged. Actual log contents: " + log_contents
+        "Expected repr of DummyClass instance (including memory address) to be logged. Actual log contents: " + log_contents
 
 
 def test_stream_logger_no_ansi_on_non_tty(logger_init):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -133,3 +133,25 @@ def test_logger_logit_logfile(tmp_path, logger_init):
     # Assert that the message contains the test file name full path
     assert 'BEGIN: tests.test_logger.add: ' + str(__file__) in log_contents, \
         "Expected test file name to be logged"
+
+def test_logger_logit_instance_method(tmp_path, logger_init):
+
+    logfile = tmp_path / "logit_instance.log"
+    logger = Logger('test_logit_instance', level=level, colored_log=True, logfile_path=logfile)
+
+    class MyClass:
+        @logit(logger)
+        def instance_method(self, x):
+            return x * 2
+
+    obj = MyClass()
+    result = obj.instance_method(5)
+    assert result == 10, "Expected instance method to return 10"
+
+    # Verify that file paths are logged
+    with open(logfile, 'r') as fh:
+        log_contents = fh.read()
+
+    # Assert that the message contains the test file name full path
+    assert 'BEGIN: tests.test_logger.instance_method: ' + str(__file__) in log_contents
+    assert 'MyClass object' in log_contents, "Expected MyClass method name to be logged. Actual log contents: " + log_contents


### PR DESCRIPTION
**Description**
When using the `logit` decorator on an instance method, this will prevent `self` from being logged. This improves readability of the logs.

Refs NOAA-emc/global-workflow#4721
Resolves https://github.com/NOAA-EMC/wxflow/issues/70

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**
Ran a global-workflow stage_ic job. This should be tested more thoroughly to ensure NCO approval of this method.

- [x] pynorms
- [x] pytests

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes