### PR TITLE
Add `copy_safe` action to FileHandler

### DIFF
--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -26,5 +26,5 @@ from .yaml_file import (YAMLFile, dump_as_yaml, parse_j2yaml, parse_yaml,
                         save_as_yaml, vanilla_yaml)
 
 __docformat__ = "restructuredtext"
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 wxflow_directory = os.path.dirname(__file__)

--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -8,7 +8,8 @@ from .exceptions import (WorkflowException, WorkflowKeyError,
 from .executable import CommandNotFoundError, Executable, ProcessError, which
 from .factory import Factory
 from .file_utils import FileHandler
-from .fsutils import chdir, chgrp, cp, get_gid, mkdir, mkdir_p, rm_p, rmdir
+from .fsutils import (chdir, chgrp, cp, cpfs, get_gid, mkdir, mkdir_p, rm_p,
+                      rmdir)
 from .hsi import Hsi
 from .htar import Htar
 from .jinja import Jinja, parse_j2tmpl

--- a/src/wxflow/__init__.py
+++ b/src/wxflow/__init__.py
@@ -8,8 +8,7 @@ from .exceptions import (WorkflowException, WorkflowKeyError,
 from .executable import CommandNotFoundError, Executable, ProcessError, which
 from .factory import Factory
 from .file_utils import FileHandler
-from .fsutils import (chdir, chgrp, cp, cpfs, get_gid, mkdir, mkdir_p, rm_p,
-                      rmdir)
+from .fsutils import chdir, chgrp, cp, get_gid, mkdir, mkdir_p, rm_p, rmdir
 from .hsi import Hsi
 from .htar import Htar
 from .jinja import Jinja, parse_j2tmpl

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -86,8 +86,12 @@ class FileHandler:
         atomically renamed onto the destination (mirrors prod_util ``cpfs``).
 
         Directory targets are handled like :func:`fsutils.cp` — the basename of
-        ``source`` is retained.
+        ``source`` is retained.  A directory ``source`` is not supported and
+        raises an ``IsADirectoryError``.
         """
+        if os.path.isdir(source):
+            raise IsADirectoryError(f"Source '{source}' is a directory; copy_safe only supports files")
+
         if os.path.isdir(target):
             target = os.path.join(target, os.path.basename(source))
 

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -2,7 +2,7 @@ import os
 from logging import getLogger
 from pathlib import Path
 
-from .fsutils import cp, mkdir
+from .fsutils import cp, cpfs, mkdir
 
 __all__ = ['FileHandler']
 
@@ -21,11 +21,13 @@ class FileHandler:
     ----
     "action" can be one of:
     "mkdir",
-    "copy", "copy_req", "copy_opt",
+    "copy", "copy_req", "copy_opt", "copy_safe",
     "link", "link_req", "link_opt", etc.
     Corresponding "act" would be ['dir1', 'dir2'], [['src1', 'dest1'], ['src2', 'dest2']]
     "copy_req" will raise an error if the source file does not exist
     "copy_opt" will not raise an error if the source file does not exist but will present a warning
+    "copy_safe" behaves like ``copy_req`` but copies via a temporary file that is fsync'd
+    and then atomically renamed onto the destination (mirrors prod_util ``cpfs``)
 
     Attributes
     ----------
@@ -53,6 +55,7 @@ class FileHandler:
             'copy': self.copy_req,
             'copy_req': self.copy_req,
             'copy_opt': self.copy_opt,
+            'copy_safe': self.copy_safe,
             'link': self.link_opt,
             'link_req': self.link_req,
             'link_opt': self.link_opt
@@ -73,7 +76,11 @@ class FileHandler:
         FileHandler._copy_files(filelist, required=False)
 
     @staticmethod
-    def _copy_files(filelist, required=True):
+    def copy_safe(filelist):
+        FileHandler._copy_files(filelist, required=True, copy_fn=cpfs)
+
+    @staticmethod
+    def _copy_files(filelist, required=True, copy_fn=cp):
         """Function to copy all files specified in the list
 
         `filelist` should be in the form:
@@ -85,6 +92,10 @@ class FileHandler:
                 List of lists of [src, dest]
         required : bool, optional
                 Flag to indicate if the src file is required to exist. Default is True
+        copy_fn : callable, optional
+                Function used to perform the individual copy, called as ``copy_fn(src, dest)``.
+                Defaults to :func:`fsutils.cp`; use :func:`fsutils.cpfs` for a fsync + atomic
+                rename copy.
         """
         for sublist in filelist:
             if len(sublist) != 2:
@@ -94,7 +105,7 @@ class FileHandler:
             dest = sublist[1]
             if os.path.exists(src):
                 try:
-                    cp(src, dest)
+                    copy_fn(src, dest)
                     logger.info(f'Copied {src} to {dest}')
                 except Exception as ee:
                     logger.exception(f"Error copying {src} to {dest}")

--- a/src/wxflow/file_utils.py
+++ b/src/wxflow/file_utils.py
@@ -1,8 +1,9 @@
 import os
+import tempfile
 from logging import getLogger
 from pathlib import Path
 
-from .fsutils import cp, cpfs, mkdir
+from .fsutils import cp, mkdir, rm_p
 
 __all__ = ['FileHandler']
 
@@ -77,7 +78,50 @@ class FileHandler:
 
     @staticmethod
     def copy_safe(filelist):
-        FileHandler._copy_files(filelist, required=True, copy_fn=cpfs)
+        FileHandler._copy_files(filelist, required=True, copy_fn=FileHandler._safe_cp)
+
+    @staticmethod
+    def _safe_cp(source, target):
+        """Copy ``source`` to ``target`` via a fsync'd temporary file that is
+        atomically renamed onto the destination (mirrors prod_util ``cpfs``).
+
+        Directory targets are handled like :func:`fsutils.cp` — the basename of
+        ``source`` is retained.
+        """
+        if os.path.isdir(target):
+            target = os.path.join(target, os.path.basename(source))
+
+        dest_dir = os.path.dirname(target) or '.'
+        if not os.path.isdir(dest_dir):
+            raise OSError(f"Destination directory {dest_dir} does not exist")
+
+        # Temp file in the destination directory keeps the rename atomic (same fs).
+        try:
+            fd, tmp_path = tempfile.mkstemp(prefix=f".{os.path.basename(target)}.",
+                                            suffix='.tmp', dir=dest_dir)
+            os.close(fd)
+        except OSError:
+            raise OSError(f"Unable to create temporary file in {dest_dir}")
+
+        try:
+            # Reuse cp() so metadata handling stays consistent with copy_req/copy_opt.
+            cp(source, tmp_path)
+
+            # Force the temp file's data to durable storage before the rename.
+            try:
+                with open(tmp_path, 'rb') as fh:
+                    os.fsync(fh.fileno())
+            except OSError:
+                raise OSError(f"Unable to fsync temporary file {tmp_path}")
+
+            # Atomic rename; overwrites target if it exists.
+            try:
+                os.replace(tmp_path, target)
+            except OSError:
+                raise OSError(f"Unable to move {tmp_path} to {target}")
+        except Exception:
+            rm_p(tmp_path, missing_ok=True)
+            raise
 
     @staticmethod
     def _copy_files(filelist, required=True, copy_fn=cp):

--- a/src/wxflow/fsutils.py
+++ b/src/wxflow/fsutils.py
@@ -1,11 +1,10 @@
 import grp
 import os
 import shutil
-import tempfile
 from contextlib import contextmanager
 from logging import getLogger
 
-__all__ = ['mkdir', 'mkdir_p', 'rmdir', 'chdir', 'rm_p', 'cp', 'cpfs',
+__all__ = ['mkdir', 'mkdir_p', 'rmdir', 'chdir', 'rm_p', 'cp',
            'get_gid', 'chgrp']
 
 logger = getLogger(__name__.split('.')[-1])
@@ -113,67 +112,6 @@ def cp(source: str, target: str) -> None:
     except Exception as ee:
         logger.exception(f"An unknown error occurred while copying {source} to {target}")
         raise ee
-
-
-def cpfs(source: str, target: str) -> None:
-    """
-    Safely copy ``source`` to ``target`` by first writing to a temporary file in
-    the destination folder, fsync'ing it to durable storage, and then atomically
-    renaming it onto the final target (overwriting any existing file).
-
-    This mirrors the behavior of the ``prod_util`` ``cpfs`` utility used when
-    staging files from ``DATA`` to ``COM``.  If ``target`` is a directory, the
-    basename of ``source`` is retained (matching :func:`cp`).
-
-    Parameters
-    ----------
-        source : str
-                 Source filename
-        target : str
-                 Destination filename or directory
-
-    Returns
-    -------
-        None
-    """
-
-    # Match cp() semantics for directory targets.
-    if os.path.isdir(target):
-        target = os.path.join(target, os.path.basename(source))
-
-    dest_dir = os.path.dirname(target) or '.'
-    if not os.path.isdir(dest_dir):
-        raise OSError(f"Destination directory {dest_dir} does not exist")
-
-    # Create a uniquely-named temporary file in the destination directory so the
-    # subsequent rename is atomic on the same filesystem.
-    try:
-        fd, tmp_path = tempfile.mkstemp(prefix=f".{os.path.basename(target)}.",
-                                        suffix='.tmp', dir=dest_dir)
-        os.close(fd)
-    except OSError:
-        raise OSError(f"Unable to create temporary file in {dest_dir}")
-
-    try:
-        # Reuse cp() for the copy so metadata is preserved consistently.
-        cp(source, tmp_path)
-
-        # Force the temp file's data to durable storage before the rename.
-        try:
-            with open(tmp_path, 'rb') as fh:
-                os.fsync(fh.fileno())
-        except OSError:
-            raise OSError(f"Unable to fsync temporary file {tmp_path}")
-
-        # Atomic rename (overwrites target if it exists).
-        try:
-            os.replace(tmp_path, target)
-        except OSError:
-            raise OSError(f"Unable to move {tmp_path} to {target}")
-    except Exception:
-        # Clean up the temp file on any failure so we don't leave debris behind.
-        rm_p(tmp_path, missing_ok=True)
-        raise
 
 
 # Group ID number for a given group name

--- a/src/wxflow/fsutils.py
+++ b/src/wxflow/fsutils.py
@@ -1,10 +1,11 @@
 import grp
 import os
 import shutil
+import tempfile
 from contextlib import contextmanager
 from logging import getLogger
 
-__all__ = ['mkdir', 'mkdir_p', 'rmdir', 'chdir', 'rm_p', 'cp',
+__all__ = ['mkdir', 'mkdir_p', 'rmdir', 'chdir', 'rm_p', 'cp', 'cpfs',
            'get_gid', 'chgrp']
 
 logger = getLogger(__name__.split('.')[-1])
@@ -112,6 +113,67 @@ def cp(source: str, target: str) -> None:
     except Exception as ee:
         logger.exception(f"An unknown error occurred while copying {source} to {target}")
         raise ee
+
+
+def cpfs(source: str, target: str) -> None:
+    """
+    Safely copy ``source`` to ``target`` by first writing to a temporary file in
+    the destination folder, fsync'ing it to durable storage, and then atomically
+    renaming it onto the final target (overwriting any existing file).
+
+    This mirrors the behavior of the ``prod_util`` ``cpfs`` utility used when
+    staging files from ``DATA`` to ``COM``.  If ``target`` is a directory, the
+    basename of ``source`` is retained (matching :func:`cp`).
+
+    Parameters
+    ----------
+        source : str
+                 Source filename
+        target : str
+                 Destination filename or directory
+
+    Returns
+    -------
+        None
+    """
+
+    # Match cp() semantics for directory targets.
+    if os.path.isdir(target):
+        target = os.path.join(target, os.path.basename(source))
+
+    dest_dir = os.path.dirname(target) or '.'
+    if not os.path.isdir(dest_dir):
+        raise OSError(f"Destination directory {dest_dir} does not exist")
+
+    # Create a uniquely-named temporary file in the destination directory so the
+    # subsequent rename is atomic on the same filesystem.
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix=f".{os.path.basename(target)}.",
+                                        suffix='.tmp', dir=dest_dir)
+        os.close(fd)
+    except OSError:
+        raise OSError(f"Unable to create temporary file in {dest_dir}")
+
+    try:
+        # Reuse cp() for the copy so metadata is preserved consistently.
+        cp(source, tmp_path)
+
+        # Force the temp file's data to durable storage before the rename.
+        try:
+            with open(tmp_path, 'rb') as fh:
+                os.fsync(fh.fileno())
+        except OSError:
+            raise OSError(f"Unable to fsync temporary file {tmp_path}")
+
+        # Atomic rename (overwrites target if it exists).
+        try:
+            os.replace(tmp_path, target)
+        except OSError:
+            raise OSError(f"Unable to move {tmp_path} to {target}")
+    except Exception:
+        # Clean up the temp file on any failure so we don't leave debris behind.
+        rm_p(tmp_path, missing_ok=True)
+        raise
 
 
 # Group ID number for a given group name

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -115,50 +115,6 @@ def test_copy(tmp_path):
         FileHandler(config).sync()
 
 
-def test_copy_safe(tmp_path):
-    """
-    Test for safely copying files via a fsync'd temporary file that is atomically
-    renamed onto the destination (mirrors prod_util ``cpfs``).
-    """
-
-    # Set up input directory with source files of known content
-    input_dir_path = tmp_path / 'my_input_dir'
-    FileHandler({'mkdir': [input_dir_path]}).sync()
-
-    src_files = [input_dir_path / 'a.txt', input_dir_path / 'b.txt']
-    for idx, ff in enumerate(src_files):
-        ff.write_text(f'contents-{idx}')
-
-    # Set up output directory and pre-populate one destination to exercise overwrite
-    output_dir_path = tmp_path / 'my_output_dir'
-    FileHandler({'mkdir': [output_dir_path]}).sync()
-    dest_files = [output_dir_path / 'a.txt', output_dir_path / 'bb.txt']
-    dest_files[0].write_text('stale')
-
-    copy_list = [[src, dest] for src, dest in zip(src_files, dest_files)]
-
-    # Test 1 (nominal) - copy_safe copies content and leaves no temp files behind
-    FileHandler({'copy_safe': copy_list}).sync()
-
-    for src, dest in zip(src_files, dest_files):
-        assert os.path.isfile(dest)
-        assert dest.read_text() == src.read_text()
-
-    # No stray temp files (mkstemp uses ".<name>." prefix + ".tmp" suffix)
-    leftovers = [p for p in os.listdir(output_dir_path) if p.endswith('.tmp')]
-    assert leftovers == []
-
-    # Test 2 - copy_safe raises when the destination directory does not exist
-    bad_copy_list = [[src_files[0], tmp_path / 'no_such_dir' / 'a.txt']]
-    with pytest.raises(OSError):
-        FileHandler({'copy_safe': bad_copy_list}).sync()
-
-    # Test 3 - copy_safe is 'required'; missing source raises FileNotFoundError
-    missing_list = [[input_dir_path / 'c.txt', output_dir_path / 'c.txt']]
-    with pytest.raises(FileNotFoundError):
-        FileHandler({'copy_safe': missing_list}).sync()
-
-
 @pytest.fixture
 def create_dirs_and_files_for_test_link(tmp_path):
     """

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -115,6 +115,50 @@ def test_copy(tmp_path):
         FileHandler(config).sync()
 
 
+def test_copy_safe(tmp_path):
+    """
+    Test for safely copying files via a fsync'd temporary file that is atomically
+    renamed onto the destination (mirrors prod_util ``cpfs``).
+    """
+
+    # Set up input directory with source files of known content
+    input_dir_path = tmp_path / 'my_input_dir'
+    FileHandler({'mkdir': [input_dir_path]}).sync()
+
+    src_files = [input_dir_path / 'a.txt', input_dir_path / 'b.txt']
+    for idx, ff in enumerate(src_files):
+        ff.write_text(f'contents-{idx}')
+
+    # Set up output directory and pre-populate one destination to exercise overwrite
+    output_dir_path = tmp_path / 'my_output_dir'
+    FileHandler({'mkdir': [output_dir_path]}).sync()
+    dest_files = [output_dir_path / 'a.txt', output_dir_path / 'bb.txt']
+    dest_files[0].write_text('stale')
+
+    copy_list = [[src, dest] for src, dest in zip(src_files, dest_files)]
+
+    # Test 1 (nominal) - copy_safe copies content and leaves no temp files behind
+    FileHandler({'copy_safe': copy_list}).sync()
+
+    for src, dest in zip(src_files, dest_files):
+        assert os.path.isfile(dest)
+        assert dest.read_text() == src.read_text()
+
+    # No stray temp files (mkstemp uses ".<name>." prefix + ".tmp" suffix)
+    leftovers = [p for p in os.listdir(output_dir_path) if p.endswith('.tmp')]
+    assert leftovers == []
+
+    # Test 2 - copy_safe raises when the destination directory does not exist
+    bad_copy_list = [[src_files[0], tmp_path / 'no_such_dir' / 'a.txt']]
+    with pytest.raises(OSError):
+        FileHandler({'copy_safe': bad_copy_list}).sync()
+
+    # Test 3 - copy_safe is 'required'; missing source raises FileNotFoundError
+    missing_list = [[input_dir_path / 'c.txt', output_dir_path / 'c.txt']]
+    with pytest.raises(FileNotFoundError):
+        FileHandler({'copy_safe': missing_list}).sync()
+
+
 @pytest.fixture
 def create_dirs_and_files_for_test_link(tmp_path):
     """

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -115,6 +115,60 @@ def test_copy(tmp_path):
         FileHandler(config).sync()
 
 
+def test_copy_safe(tmp_path):
+    """
+    Test for safely copying files via a fsync'd temporary file that is atomically
+    renamed onto the destination (mirrors prod_util ``cpfs``).
+    Parameters
+    ----------
+    tmp_path - pytest fixture
+    """
+
+    # Create the input directory with source files of known content
+    input_dir_path = tmp_path / 'my_input_dir'
+    FileHandler({'mkdir': [input_dir_path]}).sync()
+
+    src_files = [input_dir_path / 'a.txt', input_dir_path / 'b.txt']
+    for idx, ff in enumerate(src_files):
+        ff.write_text(f'contents-{idx}')
+
+    # Create output directory; pre-populate one destination to exercise overwrite
+    output_dir_path = tmp_path / 'my_output_dir'
+    FileHandler({'mkdir': [output_dir_path]}).sync()
+    dest_files = [output_dir_path / 'a.txt', output_dir_path / 'bb.txt']
+    dest_files[0].write_text('stale')
+
+    copy_list = [[src, dest] for src, dest in zip(src_files, dest_files)]
+
+    # Test 1 (nominal) - content is copied correctly and overwrites existing dest
+    FileHandler({'copy_safe': copy_list}).sync()
+    for src, dest in zip(src_files, dest_files):
+        assert os.path.isfile(dest)
+        assert dest.read_text() == src.read_text()
+
+    # Test 2 - no leftover temporary files remain in the destination directory
+    leftovers = [p for p in os.listdir(output_dir_path) if p.endswith('.tmp')]
+    assert leftovers == []
+
+    # Test 3 - a directory target retains the source basename
+    FileHandler({'copy_safe': [[src_files[0], output_dir_path]]}).sync()
+    assert (output_dir_path / 'a.txt').read_text() == src_files[0].read_text()
+
+    # Test 4 - copy_safe is 'required'; a missing source raises FileNotFoundError
+    missing = input_dir_path / 'c.txt'
+    with pytest.raises(FileNotFoundError, match=f"Source file '{missing}' does not exist"):
+        FileHandler({'copy_safe': [[missing, output_dir_path / 'c.txt']]}).sync()
+
+    # Test 5 - a non-existent destination directory raises OSError
+    bad_dest = tmp_path / 'no_such_dir' / 'a.txt'
+    with pytest.raises(OSError, match="Destination directory .* does not exist"):
+        FileHandler({'copy_safe': [[src_files[0], bad_dest]]}).sync()
+
+    # Test 6 - a directory source is not supported and raises IsADirectoryError
+    with pytest.raises(IsADirectoryError, match="is a directory"):
+        FileHandler({'copy_safe': [[input_dir_path, output_dir_path / 'dir_copy']]}).sync()
+
+
 @pytest.fixture
 def create_dirs_and_files_for_test_link(tmp_path):
     """


### PR DESCRIPTION
**Description**

- Adds a `copy_safe` action to `FileHandler`, a third copy operation alongside `copy_req` and `copy_opt`. It mirrors `prod_util cpfs` for staging files from DATA to COM: copy to a temp file in the destination folder, fsync it, then atomically rename it onto the final name (overwriting if needed), with error checking at each step and temp-file cleanup on failure.

**Type of change**
- New feature (non-breaking change which adds functionality)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**How Has This Been Tested?**

- Ran pynorms (pycodestyle + isort) and pytest locally on Linux (Python 3.12); all pass. Added `test_copy_safe` covering the nominal copy, overwrite, directory target, and the missing-source / missing-dir / directory-source error paths.

- [x] pynorms
- [x] pytests

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes need updates to the documentation. I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass with my changes
- [x] Any dependent changes have been merged and published
